### PR TITLE
Run the local scan in the background instead of during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
+## 1.2.2 — 2026-08-12
+
+* **Setup no longer waits for the local scan** (#1). The scan ran inside the
+  coordinator's first update, and config entry setup waits on that update, so
+  on a system with many custom integrations adding Breakage Radar could hang
+  long enough for setup to be cancelled mid-scan. The scan now runs as a
+  background task: the sensor comes up with index-based results right away and
+  local results replace them when the scan finishes. Refreshes behave the same
+  way, so a slow scan can never block anything again.
+
 ## 1.2.1 — 2026-08-12
 
 * **The `imminent` date estimate now uses Home Assistant's actual published

--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ Everything below is covered by a test.
 | An installed integration's file will not parse or decode | counted in `unparsed_files`; the domain stays unknown with a reason, never falsely clean |
 | An installed integration exceeds the local scan caps | counted in `skipped_files`; the index verdict is used if there is one |
 | The local scan itself fails unexpectedly | logged, and the report falls back to index-only matching |
+| The local scan is slow (many integrations, slow disk) | nothing waits for it: setup and refreshes return index results immediately, local results follow when the background scan finishes |
 | Home Assistant is upgraded past a finding's deadline | the finding stays, reclassified `broken_now`, and Repairs escalates to ERROR |
 | A release label cannot be turned into a date | no `imminent` opinion is formed; the finding is summarised rather than guessed at |
 | The index ships no matchable rules | domains scan `unknown` with a reason — an empty rule set never reads as clean |

--- a/custom_components/breakage_radar/coordinator.py
+++ b/custom_components/breakage_radar/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import aiohttp
@@ -43,6 +43,11 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         #: ``domain -> (signature, result)``; lets the 12-hourly refresh skip
         #: re-parsing any integration whose files and rules have not changed.
         self._scan_cache: dict[str, Any] = {}
+        #: Last completed local scan. Updates never wait for a scan; see
+        #: async_run_local_scan (and issue #1) for why.
+        self._local_scan: dict[str, Any] | None = None
+        self._installed: dict[str, str] = {}
+        self._scan_lock = asyncio.Lock()
 
     async def _fetch_index(self) -> dict[str, Any]:
         session = async_get_clientsession(self.hass)
@@ -63,7 +68,7 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         f"for {self.index_url}"
                     )
                 body = await response.text()
-        except asyncio.TimeoutError as err:
+        except TimeoutError as err:
             raise UpdateFailed(
                 f"Timed out after {FETCH_TIMEOUT}s fetching {self.index_url}"
             ) from err
@@ -100,22 +105,30 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.last_error = None
         self._index = index
 
-        components_dir = self.hass.config.path("custom_components")
+        # Discovery is one scandir plus a manifest.json per component, cheap
+        # enough to do inline. The scan is not, so it goes to the background
+        # and this update returns with whatever the last scan produced.
+        self._installed = await self.hass.async_add_executor_job(
+            discover_installed, self.hass.config.path("custom_components")
+        )
+        self._schedule_local_scan()
+        return self._compose(index, self._installed, self._local_scan)
+
+    def _compose(
+        self,
+        index: dict[str, Any],
+        installed: dict[str, str],
+        local_scan: dict[str, Any] | None,
+    ) -> dict[str, Any]:
         current_version = getattr(ha_const, "__version__", "") or index.get(
             "core_version", ""
-        )
-        installed = await self.hass.async_add_executor_job(
-            discover_installed, components_dir
-        )
-        local_scan = await self.hass.async_add_executor_job(
-            self._scan_local, components_dir, index, current_version
         )
         report = build_report(
             index,
             installed,
             local_scan,
             current_version=current_version,
-            today=datetime.now(timezone.utc).date(),
+            today=datetime.now(UTC).date(),
         )
         _LOGGER.debug(
             "Breakage Radar: %d of %d custom integrations affected "
@@ -130,6 +143,43 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             (local_scan or {}).get("cached_domains", 0),
         )
         return report
+
+    def _schedule_local_scan(self) -> None:
+        create = getattr(self.hass, "async_create_background_task", None)
+        if create is not None:
+            create(self.async_run_local_scan(), name=f"{DOMAIN}_local_scan")
+        else:  # pragma: no cover - cores older than 2022.10
+            self.hass.async_create_task(self.async_run_local_scan())
+
+    async def async_run_local_scan(self) -> None:
+        """Scan the installed source in the background, then publish.
+
+        Parsing every installed integration can take minutes on a slow box,
+        and config entry setup waits on the first update, so the scan must
+        never run inside one (issue #1: setup cancelled mid-scan). Instead the
+        sensor starts with index-only results and this replaces them when the
+        scan lands. The per-domain mtime cache makes repeat runs cheap, so it
+        is fine to do this on every refresh.
+        """
+        async with self._scan_lock:
+            index = self._index
+            if index is None:
+                return
+            current_version = getattr(ha_const, "__version__", "") or index.get(
+                "core_version", ""
+            )
+            scan = await self.hass.async_add_executor_job(
+                self._scan_local,
+                self.hass.config.path("custom_components"),
+                index,
+                current_version,
+            )
+            if scan is None:
+                return  # failure already logged; keep the previous results
+            self._local_scan = scan
+            self.async_set_updated_data(
+                self._compose(index, self._installed, scan)
+            )
 
     def _scan_local(
         self, components_dir: str, index: dict[str, Any], current_version: str

--- a/custom_components/breakage_radar/manifest.json
+++ b/custom_components/breakage_radar/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/Booyaka101/hass-breakage-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-breakage-radar"
-version = "1.2.1"
+version = "1.2.2"
 description = "Find out which of your Home Assistant custom integrations stop working, and in which future release."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,10 @@ def _install_homeassistant_stubs() -> None:
             self.data = None
             self.last_update_success = True
 
+        def async_set_updated_data(self, data):
+            self.data = data
+            self.last_update_success = True
+
     class CoordinatorEntity:  # noqa: D101
         def __class_getitem__(cls, item):
             return cls

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,149 @@
+"""The coordinator's update flow, issue #1 in particular.
+
+Setup waits on the first update, so the first update must never wait on the
+local scan. These drive the real BreakageRadarCoordinator with a fake hass
+that records what was scheduled where.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+
+import pytest
+
+from custom_components.breakage_radar.coordinator import BreakageRadarCoordinator
+
+
+class FakeConfig:
+    def __init__(self, components_dir):
+        self._dir = str(components_dir)
+
+    def path(self, *parts):
+        return self._dir
+
+
+class FakeHass:
+    """Just enough hass: an executor and a background task queue."""
+
+    def __init__(self, components_dir):
+        self.config = FakeConfig(components_dir)
+        self.background_tasks = []
+
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+    def async_create_background_task(self, coro, name=None):
+        self.background_tasks.append(coro)
+        return coro
+
+
+@pytest.fixture
+def sample_index(fixtures_dir):
+    return json.loads(
+        (fixtures_dir / "index_sample.json").read_text(encoding="utf-8")
+    )
+
+
+@pytest.fixture
+def coordinator(tmp_path, fixtures_dir, sample_index):
+    """A coordinator over a tmp custom_components with the true-positive
+    fixture installed, index fetch stubbed out."""
+    components = tmp_path / "custom_components"
+    source = fixtures_dir / "true_positive" / "custom_components" / "fixture_tracker"
+    shutil.copytree(source, components / "fixture_tracker")
+    (components / "fixture_tracker" / "manifest.json").write_text(
+        json.dumps({"domain": "fixture_tracker", "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+
+    coordinator = BreakageRadarCoordinator(FakeHass(components))
+
+    async def fake_fetch():
+        return sample_index
+
+    coordinator._fetch_index = fake_fetch
+    return coordinator
+
+
+def test_first_update_does_not_wait_for_the_scan(coordinator, monkeypatch):
+    """The bug behind issue #1: the scan ran inside the first update, so
+    config entry setup sat waiting on it and got cancelled."""
+    scanned = []
+    monkeypatch.setattr(
+        coordinator,
+        "_scan_local",
+        lambda *args: scanned.append(args) or None,
+    )
+
+    report = asyncio.run(coordinator._async_update_data())
+
+    # The update finished without the scan having run...
+    assert scanned == []
+    # ...but scheduled it in the background,
+    assert len(coordinator.hass.background_tasks) == 1
+    # and still produced a usable index-based report meanwhile.
+    assert report["affected_domains"] == ["fixture_tracker"]
+    assert report["details"][0]["source"] == "index"
+    assert report["local_scan_enabled"] is False
+    for task in coordinator.hass.background_tasks:
+        task.close()
+
+
+def test_background_scan_publishes_local_results(coordinator):
+    async def run():
+        await coordinator._async_update_data()
+        for task in coordinator.hass.background_tasks:
+            await task
+
+    asyncio.run(run())
+
+    report = coordinator.data
+    assert report["local_scan_enabled"] is True
+    assert report["details"][0]["source"] == "local"
+    assert report["details"][0]["line"] == 12
+    assert report["files_scanned"] == 1
+
+
+def test_a_failed_scan_keeps_the_index_results(coordinator, monkeypatch):
+    monkeypatch.setattr(coordinator, "_scan_local", lambda *args: None)
+
+    async def run():
+        report = await coordinator._async_update_data()
+        for task in coordinator.hass.background_tasks:
+            await task
+        return report
+
+    report = asyncio.run(run())
+    assert report["affected_domains"] == ["fixture_tracker"]
+    assert report["details"][0]["source"] == "index"
+    # The failed scan must not have published anything worse.
+    assert coordinator.data is None or coordinator.data == report
+
+
+def test_scan_before_any_index_is_a_no_op(coordinator):
+    asyncio.run(coordinator.async_run_local_scan())
+    assert coordinator.data is None
+
+
+def test_next_refresh_reuses_the_last_scan_without_waiting(coordinator, monkeypatch):
+    async def run():
+        await coordinator._async_update_data()
+        for task in coordinator.hass.background_tasks:
+            await task
+        coordinator.hass.background_tasks.clear()
+
+        # Second refresh: the scan from last time is used immediately, and a
+        # new background scan is scheduled rather than awaited.
+        monkeypatch.setattr(
+            coordinator, "_scan_local", lambda *args: pytest.fail("waited on scan")
+        )
+        report = await coordinator._async_update_data()
+        for task in coordinator.hass.background_tasks:
+            task.close()
+        return report
+
+    report = asyncio.run(run())
+    assert report["details"][0]["source"] == "local"
+    assert report["local_scan_enabled"] is True


### PR DESCRIPTION
Ref #1 (leaving it open until the reporter confirms).

The traceback in #1 shows setup being cancelled while the local scan was running. Since 1.1.0 the scan ran inside the coordinator's first update, and config entry setup waits on that update. Parsing every installed integration can take minutes on a slow box, so setup could hang long enough for something to cancel it. That's a design mistake on the setup path, independent of whatever cancelled it in this particular case.

What changed:

- The first update does the cheap part inline (discover what's installed) and returns an index-only report immediately. Setup now completes in the time it takes to fetch the index.
- The scan runs as a background task and publishes updated results through `async_set_updated_data` when it finishes. On a big system that means the sensor shows index results first and local results a minute later, which is the right trade.
- Every refresh works the same way. The per-domain mtime cache already makes repeat scans cheap, so there's no need for the update to ever wait.
- A failed scan keeps the previous results and logs, same as before.

Five new coordinator tests, including one that fails if the scan ever runs inside `_async_update_data` again. 159 passed / 3 skipped locally on 3.11 and 3.12.

Not merging until CI is green. Version bumped to 1.2.2 with a changelog entry so the release is a tag away after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)