### PR TITLE
Show what breaks when, and let people choose the alert window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
+## 1.3.0 — 2026-08-12
+
+### You can now see what breaks when (#3)
+
+The summary notification used to list affected integrations in one flat line
+and their release deadlines in another, so with 13 affected you could not tell
+which one broke in which release. It now shows a dated schedule:
+
+```
+2026.10 - October 2026, about 2 months away: argoclima, miele, thermia and 1 more
+2026.11 - November 2026, about 3 months away: bosch, octopus_energy, spook
+2027.8  - August 2027, about a year away: yandex_station
+```
+
+* Dates are written the way a person would say them, not as day counts.
+* The same schedule is on the sensor as a `schedule` attribute, and every
+  `details` entry gained a readable `due` field, so it is easy to build a
+  dashboard card from it.
+* Releases sort numerically, so `2027.10` comes after `2027.9`.
+
+### The alert window is configurable
+
+**Settings > Devices & Services > Breakage Radar > Configure.** Choose how far
+ahead a deadline gets its own notification: 30, 60 or 90 days, 6 months or a
+year. The default stays 30 days, and changing it applies immediately without a
+restart.
+
+At most five notifications are raised at once, however wide the window. A
+90 day window on a system with 13 affected integrations would otherwise have
+raised 13 separate notifications; the rest stay in the summary, which lists
+every date anyway.
+
+### Wording
+
+All three notifications were rewritten to say what happened and what to do
+about it, without jargon. The options screen explains what the setting changes.
+
 ## 1.2.2 — 2026-08-12
 
 * **Setup no longer waits for the local scan** (#1). The scan ran inside the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,34 @@ At most five notifications are raised at once, however wide the window. A
 raised 13 separate notifications; the rest stay in the summary, which lists
 every date anyway.
 
+### Notifications link to where you need to go
+
+Each per-integration notification now links straight to that integration's
+releases page and its issue tracker, plus the Home Assistant change that
+causes the break. The summary links the public board. Previously every
+notification pointed at the same project homepage.
+
+### The sensor no longer breaks the recorder
+
+With nine affected integrations the sensor produced 19 KB of state attributes,
+past the recorder's 16 KB limit, so Home Assistant logged a warning and stored
+**none** of them. The sensor now carries a compact summary (7 KB in the same
+situation, and a test pins it under the limit for 300 findings):
+
+* `details` is now `findings`, trimmed to the fields worth templating on.
+* The full report, with every message, link and version, moved to
+  **Download diagnostics** on the integration page.
+* `by_release` is gone. `schedule` carries the same information with dates.
+* `not_in_index` is now `not_analysed`, and `clean_domains` became
+  `clean_count`.
+
 ### Wording
 
-All three notifications were rewritten to say what happened and what to do
-about it, without jargon. The options screen explains what the setting changes.
+All three notifications and the options screen were rewritten to say what
+happened and what to do about it. The entity is now called "Affected
+integrations" rather than "Affected", titles say "1 integration" or
+"9 integrations" instead of "integration(s)", and the setup screen explains
+what the integration is for rather than only how it fetches data.
 
 ## 1.2.2 — 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,16 @@ Assistant install.
 Copy `custom_components/breakage_radar/` into your Home Assistant `config/custom_components/`
 directory and restart, then add the integration from the UI.
 
-The config flow has a single confirmation step — there is nothing to configure.
+The config flow has a single confirmation step. One setting is available afterwards
+under **Configure**: how far ahead a deadline gets its own notification.
 
 ### What you get
 
 `sensor.breakage_radar_affected` — the number of installed custom integrations with at
-least one finding.
+least one finding. The full report, including every message and link, is one click away
+under **Download diagnostics** on the integration's page.
 
-Findings come from two sources, and every `details` entry says which:
+Findings come from two sources, and every `findings` entry says which:
 
 * `source: local` — the integration parsed the **installed bytes** in your own
   `custom_components/` directory with the same eight AST matchers the crawler
@@ -108,10 +110,13 @@ Findings come from two sources, and every `details` entry says which:
 ```yaml
 state: 2
 attributes:
-  by_release:
-    "2027.5": [some_tracker]
-    "2027.8": [some_tracker, another_integration]
-  details:
+  schedule:
+    - release: "2027.5"
+      due: "May 2027, about 9 months away"
+      when: imminent
+      domains: [some_tracker]
+      count: 1
+  findings:
     - domain: some_tracker
       rule_id: legacy-device-tracker-platform
       breaks_in: "2027.5"
@@ -121,11 +126,6 @@ attributes:
       source: local
       when: imminent        # broken_now | imminent | upcoming
       days_until: 21
-      repository: someone/some-tracker
-      scanned_version: "1.3.2"
-      installed_version: "1.3.2"
-      message: "Implements the legacy (non-config-entry) device tracker platform API..."
-      learn_more: https://developers.home-assistant.io/blog/2026/04/20/legacy-device-tracker-deprecation/
   index_generated_utc: "2026-08-11T03:57:51Z"
   affected_domains: [some_tracker, another_integration]
   broken_now: {}
@@ -133,11 +133,9 @@ attributes:
   imminent:
     some_tracker: {release: "2027.5", days: 21}
   imminent_count: 1
-  summarised_domains: [another_integration]
   alert_window_days: 30
-  not_in_index: [broken_thing]
-  not_in_index_reasons:
-    broken_thing: "1 of 3 Python file(s) could not be parsed"
+  not_analysed: [broken_thing]
+  clean_count: 4
   files_scanned: 412
   unparsed_files: 1
   skipped_files: 0
@@ -146,8 +144,8 @@ attributes:
 ```
 
 A domain that is nowhere in the index but parses clean locally lands in
-`clean_domains`; only a domain **neither** side could analyse stays in
-`not_in_index`, with the reason alongside. `files_scanned`, `unparsed_files` and
+the clean count; only a domain **neither** side could analyse stays in
+`not_analysed`. `files_scanned`, `unparsed_files` and
 `skipped_files` make a truncated scan visible — it is never silently reported
 as clean. The scan runs in an executor and is cached on each integration's file
 count, newest mtime, total size and the rules fingerprint, so the 12-hourly
@@ -415,7 +413,7 @@ produces **exactly one** finding:
 ```
 
 and with it installed the sensor reads `1` with
-`by_release == {"2027.5": ["fixture_tracker"]}`.
+`schedule[0] == {release: "2027.5", domains: ["fixture_tracker"], ...}`.
 
 Lookalikes produce **zero** findings — `setup_scanner` inside a class body is a method,
 and `setup_scanner` in `sensor.py` is just a function with an unlucky name. Both are

--- a/README.md
+++ b/README.md
@@ -160,8 +160,21 @@ Every finding is sorted by how soon it bites, and that decides how loudly it app
 | Level | When | What you see |
 |---|---|---|
 | `broken_now` | your running Home Assistant already reached the deadline | one **ERROR** Repairs issue per integration |
-| `imminent` | the release is due within 30 days | one **WARNING** Repairs issue per integration |
-| `upcoming` | further out | **one** summary issue, grouped by release |
+| `imminent` | the release is due inside the alert window (30 days by default) | one **WARNING** Repairs issue per integration, up to five |
+| `upcoming` | further out | **one** summary issue listing what breaks in each release |
+
+The summary tells you which integration breaks when, not just how many:
+
+```
+2026.10 - October 2026, about 2 months away: argoclima, miele, thermia
+2026.11 - November 2026, about 3 months away: bosch, octopus_energy, spook
+2027.8  - August 2027, about a year away: yandex_station
+```
+
+Change the window under **Settings → Devices & Services → Breakage Radar →
+Configure**: 30, 60 or 90 days, 6 months or a year. It applies immediately. However
+wide the window, at most five notifications are raised at once, since the summary
+lists every date anyway.
 
 The point of the split is that Repairs has no snooze button. A dozen cards for
 deadlines a year away would only teach you to ignore the panel — which is where every
@@ -460,7 +473,12 @@ index changing shape for it.
 
 ## Configuration
 
-The Home Assistant integration needs none. For the crawler:
+The Home Assistant integration has one setting, under **Settings → Devices &
+Services → Breakage Radar → Configure**: how far ahead a deadline gets its own
+notification (30, 60 or 90 days, 6 months, or a year). Everything outside that
+window is listed in the summary instead.
+
+For the crawler:
 
 | Setting | Where | Default |
 |---|---|---|

--- a/custom_components/breakage_radar/__init__.py
+++ b/custom_components/breakage_radar/__init__.py
@@ -13,7 +13,12 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 
-from .const import DOMAIN, ISSUE_ID
+from .const import (
+    ALERT_WINDOW_DAYS,
+    CONF_ALERT_WINDOW_DAYS,
+    DOMAIN,
+    ISSUE_ID,
+)
 from .coordinator import BreakageRadarCoordinator
 from .repairs import ALERT_PREFIXES, async_sync_issue
 
@@ -24,23 +29,34 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Breakage Radar from a config entry."""
-    coordinator = BreakageRadarCoordinator(hass)
+    coordinator = BreakageRadarCoordinator(
+        hass,
+        alert_window_days=entry.options.get(
+            CONF_ALERT_WINDOW_DAYS, ALERT_WINDOW_DAYS
+        ),
+    )
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     @callback
     def _handle_update() -> None:
-        """Keep the repairs issue in step with every refresh."""
+        """Keep the repairs issues in step with every refresh."""
         if coordinator.last_update_success and coordinator.data:
             async_sync_issue(hass, coordinator.data)
 
     entry.async_on_unload(coordinator.async_add_listener(_handle_update))
+    entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
     if coordinator.data:
         async_sync_issue(hass, coordinator.data)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Apply a changed alert window without needing a restart."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/breakage_radar/config_flow.py
+++ b/custom_components/breakage_radar/config_flow.py
@@ -1,12 +1,31 @@
-"""Config flow: a single confirmation step, no user input needed."""
+"""Config flow: one confirmation step, plus options for the alert window."""
 
 from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+import voluptuous as vol
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
-from .const import DOMAIN, INDEX_URL, NAME
+from .const import (
+    ALERT_WINDOW_CHOICES,
+    ALERT_WINDOW_DAYS,
+    CONF_ALERT_WINDOW_DAYS,
+    DOMAIN,
+    INDEX_URL,
+    NAME,
+)
 
 
 class BreakageRadarConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -28,3 +47,40 @@ class BreakageRadarConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             description_placeholders={"index_url": INDEX_URL},
         )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(entry: ConfigEntry) -> BreakageRadarOptionsFlow:
+        return BreakageRadarOptionsFlow()
+
+
+class BreakageRadarOptionsFlow(OptionsFlow):
+    """How far ahead a deadline is worth its own notification."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        if user_input is not None:
+            return self.async_create_entry(
+                data={
+                    CONF_ALERT_WINDOW_DAYS: int(user_input[CONF_ALERT_WINDOW_DAYS])
+                }
+            )
+
+        current = self.config_entry.options.get(
+            CONF_ALERT_WINDOW_DAYS, ALERT_WINDOW_DAYS
+        )
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_ALERT_WINDOW_DAYS, default=str(current)
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[str(days) for days in ALERT_WINDOW_CHOICES],
+                        mode=SelectSelectorMode.DROPDOWN,
+                        translation_key=CONF_ALERT_WINDOW_DAYS,
+                    )
+                )
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/breakage_radar/const.py
+++ b/custom_components/breakage_radar/const.py
@@ -19,9 +19,13 @@ UPDATE_INTERVAL: Final = timedelta(hours=12)
 #: Network timeout for one index fetch, in seconds.
 FETCH_TIMEOUT: Final = 30
 
-#: Hard cap on the ``details`` attribute so a very affected system cannot
-#: produce a state object Home Assistant refuses to store.
-MAX_DETAILS: Final = 100
+#: Findings kept in the report. Everything beyond this is counted but not
+#: listed; the full set is in the downloadable diagnostics.
+MAX_DETAILS: Final = 200
+
+#: Findings put on the sensor. The recorder drops state attributes over 16 KB,
+#: so this stays well inside it even with long file paths.
+MAX_SENSOR_FINDINGS: Final = 40
 
 #: Deadlines inside this many days get their own notification; everything else
 #: is listed in the summary. Configurable per entry via the options flow.
@@ -38,6 +42,6 @@ MAX_ALERT_CARDS: Final = 5
 
 ISSUE_ID: Final = "integrations_affected"
 
-ATTR_BY_RELEASE: Final = "by_release"
-ATTR_DETAILS: Final = "details"
+ATTR_SCHEDULE: Final = "schedule"
+ATTR_DETAILS: Final = "findings"
 ATTR_INDEX_GENERATED: Final = "index_generated_utc"

--- a/custom_components/breakage_radar/const.py
+++ b/custom_components/breakage_radar/const.py
@@ -23,10 +23,18 @@ FETCH_TIMEOUT: Final = 30
 #: produce a state object Home Assistant refuses to store.
 MAX_DETAILS: Final = 100
 
-#: A deadline this close gets its own alert instead of being summarised with
-#: the rest. Home Assistant releases on the first Wednesday of every month
-#: (home-assistant.io/faq/release/), so 30 days means "the next release".
+#: Deadlines inside this many days get their own notification; everything else
+#: is listed in the summary. Configurable per entry via the options flow.
 ALERT_WINDOW_DAYS: Final = 30
+
+CONF_ALERT_WINDOW_DAYS: Final = "alert_window_days"
+
+#: Offered in the options flow, in days.
+ALERT_WINDOW_CHOICES: Final = (30, 60, 90, 180, 365)
+
+#: However wide the window, only the nearest few deadlines get their own
+#: notification. The rest stay in the summary, which lists every date anyway.
+MAX_ALERT_CARDS: Final = 5
 
 ISSUE_ID: Final = "integrations_affected"
 

--- a/custom_components/breakage_radar/coordinator.py
+++ b/custom_components/breakage_radar/coordinator.py
@@ -14,7 +14,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, FETCH_TIMEOUT, INDEX_URL, UPDATE_INTERVAL
+from .const import (
+    ALERT_WINDOW_DAYS,
+    DOMAIN,
+    FETCH_TIMEOUT,
+    INDEX_URL,
+    UPDATE_INTERVAL,
+)
 from .discovery import discover_installed
 from .report import build_report, validate_index
 from .scanner import scan_installed
@@ -30,7 +36,12 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     instead of raising or reporting stale data as fresh.
     """
 
-    def __init__(self, hass: HomeAssistant, index_url: str = INDEX_URL) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        index_url: str = INDEX_URL,
+        alert_window_days: int = ALERT_WINDOW_DAYS,
+    ) -> None:
         super().__init__(
             hass,
             _LOGGER,
@@ -38,6 +49,7 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=UPDATE_INTERVAL,
         )
         self.index_url = index_url
+        self.alert_window_days = alert_window_days
         self.last_error: str | None = None
         self._index: dict[str, Any] | None = None
         #: ``domain -> (signature, result)``; lets the 12-hourly refresh skip
@@ -129,6 +141,7 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             local_scan,
             current_version=current_version,
             today=datetime.now(UTC).date(),
+            alert_window_days=self.alert_window_days,
         )
         _LOGGER.debug(
             "Breakage Radar: %d of %d custom integrations affected "

--- a/custom_components/breakage_radar/diagnostics.py
+++ b/custom_components/breakage_radar/diagnostics.py
@@ -1,0 +1,55 @@
+"""Downloadable diagnostics: the full report, including every finding.
+
+The sensor carries a compact summary, because Home Assistant's recorder
+refuses to store state attributes over 16 KB and a system with many findings
+went well past that. Everything is here instead, one click from the
+integration page.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import BreakageRadarCoordinator
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return the full breakage report for this system."""
+    coordinator: BreakageRadarCoordinator = hass.data[DOMAIN][entry.entry_id]
+    report = coordinator.data or {}
+
+    return {
+        "index": {
+            "url": coordinator.index_url,
+            "generated_utc": report.get("index_generated_utc"),
+            "core_version": report.get("index_core_version"),
+            "schema": report.get("index_schema"),
+        },
+        "settings": {"alert_window_days": coordinator.alert_window_days},
+        "scan": {
+            "enabled": report.get("local_scan_enabled"),
+            "files_scanned": report.get("files_scanned"),
+            "unparsed_files": report.get("unparsed_files"),
+            "skipped_files": report.get("skipped_files"),
+        },
+        "summary": {
+            "installed": report.get("installed_count"),
+            "affected": report.get("affected_count"),
+            "broken_now": report.get("broken_now"),
+            "imminent": report.get("imminent"),
+            "clean": report.get("clean_domains"),
+            "not_analysed": report.get("not_in_index"),
+            "not_analysed_reasons": report.get("not_in_index_reasons"),
+        },
+        "schedule": report.get("schedule"),
+        # Every finding, with the message and links the sensor has to leave out.
+        "findings": report.get("details"),
+        "findings_truncated": report.get("details_truncated"),
+        "total_findings": report.get("total_findings"),
+    }

--- a/custom_components/breakage_radar/discovery.py
+++ b/custom_components/breakage_radar/discovery.py
@@ -1,12 +1,9 @@
-"""Finding the custom integrations installed on this system.
+"""Finds the custom integrations installed on this system.
 
-Free of any ``homeassistant`` import so it can be unit-tested without a Home
-Assistant install. Blocking I/O -- call from an executor.
-
-The domain a component *declares* in its ``manifest.json`` is the key
-everything else joins on. A forked or renamed checkout has a directory name
-that differs from its domain, so resolving it in one place is what stops a
-finding being dropped between the scan and the report.
+Blocking I/O, so call from an executor. The domain a component declares in its
+manifest is the key the scan, the index lookup and the report all join on; a
+fork can have a directory name that differs from it, so it is resolved here
+and nowhere else.
 """
 
 from __future__ import annotations
@@ -14,17 +11,14 @@ from __future__ import annotations
 import json
 import os
 
-#: Never treat these as installed custom integrations.
 IGNORED_DIRECTORIES = frozenset({"__pycache__", ".git", ".github"})
 
 
 def discover_installed(custom_components_dir: str) -> dict[str, str]:
     """Return ``{domain: version}`` for every custom integration on disk.
 
-    Blocking I/O -- call from an executor. A directory without a readable
-    ``manifest.json`` still counts as installed (version ``""``), because HACS
-    repositories occasionally ship a malformed manifest and the user still wants
-    to know the component is there.
+    A component whose manifest is missing or malformed still counts as
+    installed, with an empty version.
     """
     installed: dict[str, str] = {}
     try:
@@ -57,13 +51,7 @@ def discover_installed(custom_components_dir: str) -> dict[str, str]:
 
 
 def _manifest_domain(directory: str, fallback: str) -> str:
-    """The domain a component directory *declares*, falling back to its name.
-
-    This is the same resolution :func:`discover_installed` uses, and it is what
-    keeps a forked or renamed checkout matched up: the scan, the discovery and
-    the index lookup must all speak the same key or a finding gets dropped
-    between them.
-    """
+    """The domain a component declares, falling back to its directory name."""
     try:
         with open(os.path.join(directory, "manifest.json"), encoding="utf-8") as handle:
             manifest = json.load(handle)

--- a/custom_components/breakage_radar/manifest.json
+++ b/custom_components/breakage_radar/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/Booyaka101/hass-breakage-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.2.2"
+  "version": "1.3.0"
 }

--- a/custom_components/breakage_radar/repairs.py
+++ b/custom_components/breakage_radar/repairs.py
@@ -56,6 +56,36 @@ def plural(count: int, singular: str, plural_form: str | None = None) -> str:
     return singular if count == 1 else (plural_form or f"{singular}s")
 
 
+def describe_links(link: dict | None) -> str:
+    """Where to go next, as a markdown sentence.
+
+    The whole point of a notification about somebody else's code is getting
+    the reader to that repository, so the links go in the body rather than
+    leaving them to search for it.
+    """
+    link = link or {}
+    repo_url = link.get("repo_url")
+    repository = link.get("repository") or "the integration's repository"
+    learn_more = link.get("learn_more") or ""
+
+    parts: list[str] = []
+    if repo_url:
+        parts.append(
+            f"Check [{repository}]({repo_url}/releases) for a newer release, "
+            f"or [open an issue]({repo_url}/issues) if there isn't one."
+        )
+    else:
+        parts.append(
+            "Check the integration's own repository for a newer release, or "
+            "raise it with whoever maintains it."
+        )
+    if learn_more.startswith("http"):
+        parts.append(f"[What Home Assistant is changing]({learn_more})")
+    elif learn_more:
+        parts.append(f"What Home Assistant is changing: `{learn_more}`")
+    return "\n\n".join(parts)
+
+
 @callback
 def _async_sync_alert_issues(hass: HomeAssistant, report: dict) -> None:
     """One card per integration that needs attention now, or soon.
@@ -66,6 +96,7 @@ def _async_sync_alert_issues(hass: HomeAssistant, report: dict) -> None:
     """
     broken: dict[str, str] = report.get("broken_now") or {}
     imminent: dict[str, dict] = report.get("imminent") or {}
+    links: dict[str, dict] = report.get("links") or {}
     due_by_release = {
         group["release"]: group["due"] for group in report.get("schedule") or []
     }
@@ -79,8 +110,12 @@ def _async_sync_alert_issues(hass: HomeAssistant, report: dict) -> None:
             is_persistent=False,
             severity=ir.IssueSeverity.ERROR,
             translation_key="integration_broken",
-            translation_placeholders={"domain": domain, "release": str(release)},
-            learn_more_url=LEARN_MORE_URL,
+            translation_placeholders={
+                "domain": domain,
+                "release": str(release),
+                "where": describe_links(links.get(domain)),
+            },
+            learn_more_url=links.get(domain, {}).get("repo_url") or LEARN_MORE_URL,
         )
 
     for domain, entry in imminent.items():
@@ -100,8 +135,9 @@ def _async_sync_alert_issues(hass: HomeAssistant, report: dict) -> None:
                 "days": str(days),
                 "day_word": plural(days, "day"),
                 "due": due_by_release.get(release, release),
+                "where": describe_links(links.get(domain)),
             },
-            learn_more_url=LEARN_MORE_URL,
+            learn_more_url=links.get(domain, {}).get("repo_url") or LEARN_MORE_URL,
         )
 
     # Anything that dropped out of a level, including an uninstalled component
@@ -155,6 +191,7 @@ def async_sync_issue(hass: HomeAssistant, report: dict) -> None:
             "earliest_due": first["due"] if first else "",
             "schedule": format_schedule(schedule, only=set(summarised)),
             "window": str(report.get("alert_window_days") or 0),
+            "board_url": LEARN_MORE_URL,
         },
         learn_more_url=LEARN_MORE_URL,
     )

--- a/custom_components/breakage_radar/repairs.py
+++ b/custom_components/breakage_radar/repairs.py
@@ -1,14 +1,8 @@
-"""Repairs issue raised when installed custom integrations are going to break.
+"""Repairs issues for integrations that are going to break.
 
-The issue is deliberately *not* fixable in place. Frenck, reviewing the legacy
-device tracker deprecation (architecture discussion 1375):
-
-    "Repairs must be user actionable, and in this case, they can't solve it."
-
-The action a user *can* take is real though: open the upstream repository's
-issue tracker, or replace the integration before the deadline. So the issue is
-informational, links straight to the board, and clears itself the moment the
-count returns to zero.
+None of these are fixable in place, because the code lives in someone else's
+repository. What the user can do is real though: update the integration, raise
+it upstream, or replace it before the deadline.
 """
 
 from __future__ import annotations
@@ -20,32 +14,54 @@ from .const import DOMAIN, ISSUE_ID
 
 LEARN_MORE_URL = "https://booyaka101.github.io/hass-breakage-radar/"
 
-
-#: Prefix for the per-integration issues raised once a deadline has passed.
 BROKEN_ISSUE_PREFIX = "broken_now_"
-
-#: Prefix for the per-integration issues raised while a deadline is close.
 IMMINENT_ISSUE_PREFIX = "imminent_"
-
 ALERT_PREFIXES = (BROKEN_ISSUE_PREFIX, IMMINENT_ISSUE_PREFIX)
+
+#: Keeps the summary description readable when a lot is scheduled.
+MAX_SCHEDULE_LINES = 8
+MAX_DOMAINS_PER_LINE = 6
+
+
+def format_schedule(schedule: list[dict], only: set[str] | None = None) -> str:
+    """A dated timeline of what breaks when, one release per line.
+
+    ``2027.5 - May 2027, about 9 months away: pycupra, some_tracker``
+    """
+    lines: list[str] = []
+    hidden = 0
+    for group in schedule:
+        domains = group.get("domains") or []
+        if only is not None:
+            domains = [d for d in domains if d in only]
+        if not domains:
+            continue
+        if len(lines) >= MAX_SCHEDULE_LINES:
+            hidden += len(domains)
+            continue
+        shown = domains[:MAX_DOMAINS_PER_LINE]
+        names = ", ".join(shown)
+        if len(domains) > len(shown):
+            names += f" and {len(domains) - len(shown)} more"
+        lines.append(f"{group['release']} - {group['due']}: {names}")
+    if hidden:
+        lines.append(f"...and {hidden} more further out.")
+    return "\n".join(lines)
 
 
 @callback
 def _async_sync_alert_issues(hass: HomeAssistant, report: dict) -> None:
-    """One issue per integration that needs attention *soon*, or already.
+    """One card per integration that needs attention now, or soon.
 
-    Two levels get their own card, because both are things a person can act on
-    this week:
-
-    * ``broken_now`` -- the deadline has passed on this system, ERROR.
-    * ``imminent``   -- the deadline is inside the alert window, WARNING.
-
-    Everything further out stays in the single summary issue. A year-ahead
-    deadline that cannot be dismissed only teaches people to ignore Repairs,
-    which is the mechanism every *other* integration relies on.
+    Everything further out stays in the single summary issue, because Repairs
+    has no snooze and a wall of undismissable year-ahead cards just trains
+    people to ignore the panel.
     """
     broken: dict[str, str] = report.get("broken_now") or {}
     imminent: dict[str, dict] = report.get("imminent") or {}
+    due_by_release = {
+        group["release"]: group["due"] for group in report.get("schedule") or []
+    }
 
     for domain, release in broken.items():
         ir.async_create_issue(
@@ -61,7 +77,7 @@ def _async_sync_alert_issues(hass: HomeAssistant, report: dict) -> None:
         )
 
     for domain, entry in imminent.items():
-        days = int(entry.get("days", 0))
+        release = str(entry.get("release", ""))
         ir.async_create_issue(
             hass,
             DOMAIN,
@@ -72,15 +88,15 @@ def _async_sync_alert_issues(hass: HomeAssistant, report: dict) -> None:
             translation_key="integration_imminent",
             translation_placeholders={
                 "domain": domain,
-                "release": str(entry.get("release", "")),
-                "days": str(max(days, 0)),
+                "release": release,
+                "days": str(max(int(entry.get("days", 0)), 0)),
+                "due": due_by_release.get(release, release),
             },
             learn_more_url=LEARN_MORE_URL,
         )
 
-    # Anything that has dropped out of a level -- recovered, moved back to the
-    # summary, or been uninstalled -- must lose its card. The registry is the
-    # only place an uninstalled component's stale issue can still be found.
+    # Anything that dropped out of a level, including an uninstalled component
+    # that has vanished from the report, must lose its card.
     async_get = getattr(ir, "async_get", None)
     if async_get is None:
         return
@@ -101,23 +117,18 @@ def async_sync_issue(hass: HomeAssistant, report: dict) -> None:
     """Create, update or clear the Breakage Radar repairs issues."""
     _async_sync_alert_issues(hass, report)
 
-    # Only the non-urgent remainder is summarised; anything with its own alert
-    # would otherwise be reported twice.
     summarised = report.get("summarised_domains") or []
     if not summarised:
         ir.async_delete_issue(hass, DOMAIN, ISSUE_ID)
         return
 
-    by_release: dict[str, list[str]] = report.get("by_release") or {}
-    remaining = {
-        release: [d for d in domains if d in set(summarised)]
-        for release, domains in by_release.items()
-    }
-    remaining = {r: d for r, d in remaining.items() if d}
-    earliest = next(iter(remaining), report.get("earliest_release") or "a future release")
-    releases = ", ".join(
-        f"{release} ({len(domains)})" for release, domains in remaining.items()
-    )
+    schedule = report.get("schedule") or []
+    remaining = [
+        group
+        for group in schedule
+        if any(domain in set(summarised) for domain in group.get("domains") or [])
+    ]
+    first = remaining[0] if remaining else None
 
     ir.async_create_issue(
         hass,
@@ -129,10 +140,10 @@ def async_sync_issue(hass: HomeAssistant, report: dict) -> None:
         translation_key="integrations_affected",
         translation_placeholders={
             "count": str(len(summarised)),
-            "earliest": str(earliest),
-            "integrations": ", ".join(sorted(summarised)[:12])
-            + (" and others" if len(summarised) > 12 else ""),
-            "releases": releases or "-",
+            "earliest": first["release"] if first else "a future release",
+            "earliest_due": first["due"] if first else "",
+            "schedule": format_schedule(schedule, only=set(summarised)),
+            "window": str(report.get("alert_window_days") or 0),
         },
         learn_more_url=LEARN_MORE_URL,
     )

--- a/custom_components/breakage_radar/repairs.py
+++ b/custom_components/breakage_radar/repairs.py
@@ -7,6 +7,8 @@ it upstream, or replace it before the deadline.
 
 from __future__ import annotations
 
+from urllib.parse import quote_plus
+
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 
@@ -57,27 +59,44 @@ def plural(count: int, singular: str, plural_form: str | None = None) -> str:
 
 
 def describe_links(link: dict | None) -> str:
-    """Where to go next, as a markdown sentence.
+    """Where to go next, as markdown.
 
-    The whole point of a notification about somebody else's code is getting
-    the reader to that repository, so the links go in the body rather than
-    leaving them to search for it.
+    Deliberately points at *existing* reports rather than a blank issue form.
+    Popular integrations have thousands of users; if each one files "this
+    breaks in 2027.5" the maintainer gets the same issue over and over. A
+    search for the deprecated symbol lands on the report if there is one, so
+    the reader can add a reaction instead of a duplicate, and shows an empty
+    result with a New issue button if there is not.
     """
     link = link or {}
-    repo_url = link.get("repo_url")
+    repo_url = (link.get("repo_url") or "").rstrip("/")
     repository = link.get("repository") or "the integration's repository"
+    symbol = link.get("symbol") or ""
     learn_more = link.get("learn_more") or ""
 
     parts: list[str] = []
     if repo_url:
         parts.append(
-            f"Check [{repository}]({repo_url}/releases) for a newer release, "
-            f"or [open an issue]({repo_url}/issues) if there isn't one."
+            f"First check [{repository} releases]({repo_url}/releases) for a "
+            "version that fixes it."
         )
+        if symbol:
+            query = quote_plus(f"is:issue {symbol}")
+            parts.append(
+                f"If there isn't one, [see whether it is already "
+                f"reported]({repo_url}/issues?q={query}). Adding a reaction to "
+                "an existing report helps the maintainer more than another "
+                "copy of it does."
+            )
+        else:
+            parts.append(
+                f"If there isn't one, check [the issue tracker]({repo_url}/issues) "
+                "before reporting it, so the maintainer does not get duplicates."
+            )
     else:
         parts.append(
-            "Check the integration's own repository for a newer release, or "
-            "raise it with whoever maintains it."
+            "Check the integration's own repository for a newer release, and "
+            "its issue tracker before reporting anything."
         )
     if learn_more.startswith("http"):
         parts.append(f"[What Home Assistant is changing]({learn_more})")

--- a/custom_components/breakage_radar/repairs.py
+++ b/custom_components/breakage_radar/repairs.py
@@ -24,9 +24,11 @@ MAX_DOMAINS_PER_LINE = 6
 
 
 def format_schedule(schedule: list[dict], only: set[str] | None = None) -> str:
-    """A dated timeline of what breaks when, one release per line.
+    """A dated timeline of what breaks when, as a markdown list.
 
-    ``2027.5 - May 2027, about 9 months away: pycupra, some_tracker``
+    A list rather than a code block because Home Assistant renders repair
+    descriptions as markdown, and a fenced block scrolls sideways instead of
+    wrapping, which hides the integration names on narrow screens.
     """
     lines: list[str] = []
     hidden = 0
@@ -40,13 +42,18 @@ def format_schedule(schedule: list[dict], only: set[str] | None = None) -> str:
             hidden += len(domains)
             continue
         shown = domains[:MAX_DOMAINS_PER_LINE]
-        names = ", ".join(shown)
+        names = ", ".join(f"`{name}`" for name in shown)
         if len(domains) > len(shown):
             names += f" and {len(domains) - len(shown)} more"
-        lines.append(f"{group['release']} - {group['due']}: {names}")
+        lines.append(f"- **{group['due']}** ({group['release']}): {names}")
     if hidden:
-        lines.append(f"...and {hidden} more further out.")
+        lines.append(f"- ...and {hidden} more further out.")
     return "\n".join(lines)
+
+
+def plural(count: int, singular: str, plural_form: str | None = None) -> str:
+    """``1 integration`` / ``9 integrations``, since a title cannot say (s)."""
+    return singular if count == 1 else (plural_form or f"{singular}s")
 
 
 @callback
@@ -78,6 +85,7 @@ def _async_sync_alert_issues(hass: HomeAssistant, report: dict) -> None:
 
     for domain, entry in imminent.items():
         release = str(entry.get("release", ""))
+        days = max(int(entry.get("days", 0)), 0)
         ir.async_create_issue(
             hass,
             DOMAIN,
@@ -89,7 +97,8 @@ def _async_sync_alert_issues(hass: HomeAssistant, report: dict) -> None:
             translation_placeholders={
                 "domain": domain,
                 "release": release,
-                "days": str(max(int(entry.get("days", 0)), 0)),
+                "days": str(days),
+                "day_word": plural(days, "day"),
                 "due": due_by_release.get(release, release),
             },
             learn_more_url=LEARN_MORE_URL,
@@ -140,6 +149,8 @@ def async_sync_issue(hass: HomeAssistant, report: dict) -> None:
         translation_key="integrations_affected",
         translation_placeholders={
             "count": str(len(summarised)),
+            "noun": plural(len(summarised), "integration"),
+            "verb": "uses" if len(summarised) == 1 else "use",
             "earliest": first["release"] if first else "a future release",
             "earliest_due": first["due"] if first else "",
             "schedule": format_schedule(schedule, only=set(summarised)),

--- a/custom_components/breakage_radar/report.py
+++ b/custom_components/breakage_radar/report.py
@@ -169,17 +169,19 @@ def build_report(
                     }
             if when in ("broken_now", "imminent"):
                 # What the notification needs to point somewhere useful.
+                rule = rules.get(finding.get("rule_id"), {})
                 links.setdefault(
                     domain,
                     {
                         "repository": (entry or {}).get("full_name", ""),
                         "repo_url": (entry or {}).get("repo_url", ""),
+                        # The deprecated symbol is the search term that finds an
+                        # existing report; a vague word like "deprecated" does not.
+                        "symbol": rule.get("symbol", ""),
                         # source_url is a real link; source can be a bare
                         # "file.py:418" reference for core-derived rules.
                         "learn_more": (
-                            rules.get(finding.get("rule_id"), {}).get("source_url")
-                            or rules.get(finding.get("rule_id"), {}).get("source")
-                            or ""
+                            rule.get("source_url") or rule.get("source") or ""
                         ),
                     },
                 )

--- a/custom_components/breakage_radar/report.py
+++ b/custom_components/breakage_radar/report.py
@@ -120,6 +120,7 @@ def build_report(
     unknown_reasons: dict[str, str] = {}
     broken_now: dict[str, str] = {}
     imminent: dict[str, dict[str, Any]] = {}
+    links: dict[str, dict[str, str]] = {}
 
     def _days_until(release: str) -> int | None:
         if today is None:
@@ -166,6 +167,22 @@ def build_report(
                         "release": release,
                         "days": days if days is not None else 0,
                     }
+            if when in ("broken_now", "imminent"):
+                # What the notification needs to point somewhere useful.
+                links.setdefault(
+                    domain,
+                    {
+                        "repository": (entry or {}).get("full_name", ""),
+                        "repo_url": (entry or {}).get("repo_url", ""),
+                        # source_url is a real link; source can be a bare
+                        # "file.py:418" reference for core-derived rules.
+                        "learn_more": (
+                            rules.get(finding.get("rule_id"), {}).get("source_url")
+                            or rules.get(finding.get("rule_id"), {}).get("source")
+                            or ""
+                        ),
+                    },
+                )
             rule = rules.get(finding.get("rule_id"), {})
             details.append(
                 {
@@ -245,12 +262,6 @@ def build_report(
     return {
         "affected_count": len(affected),
         "affected_domains": affected,
-        "by_release": {
-            release: sorted(domains)
-            for release, domains in sorted(
-                by_release.items(), key=lambda item: parse_version(item[0])
-            )
-        },
         "details": details[:MAX_DETAILS],
         "details_truncated": truncated,
         "total_findings": len(details),
@@ -262,6 +273,7 @@ def build_report(
         "broken_now_count": len(broken_now),
         "imminent": imminent,
         "imminent_count": len(imminent),
+        "links": links,
         "schedule": schedule,
         "summarised_domains": sorted(
             set(affected) - set(broken_now) - set(imminent)

--- a/custom_components/breakage_radar/report.py
+++ b/custom_components/breakage_radar/report.py
@@ -1,11 +1,8 @@
-"""Turning the index and the local scan into the sensor's state.
+"""Turns the index and the local scan into the sensor's state.
 
-Deliberately free of any ``homeassistant`` import so the exact code that runs
-on a real box can be unit-tested without a Home Assistant install, and free of
-I/O: :func:`build_report` is a pure function of (index, local scan, clock).
-
-Discovery lives in :mod:`.discovery` and scanning in :mod:`.scanner`; this
-module only decides what the two of them add up to.
+Free of any ``homeassistant`` import and of I/O, so the code that runs on a
+real system can be tested without one. Discovery lives in :mod:`.discovery`,
+scanning in :mod:`.scanner`.
 """
 
 from __future__ import annotations
@@ -13,21 +10,27 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Any
 
-from .const import ALERT_WINDOW_DAYS, MAX_DETAILS, SUPPORTED_SCHEMA
+from .const import (
+    ALERT_WINDOW_DAYS,
+    MAX_ALERT_CARDS,
+    MAX_DETAILS,
+    SUPPORTED_SCHEMA,
+)
 from .rules_engine import is_future, parse_version
+
+MONTH_NAMES = (
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+)
 
 
 def release_estimated_date(release: str) -> date | None:
-    """Expected calendar date of a Home Assistant release label.
+    """Expected date of a release label, or None if it cannot be parsed.
 
-    Home Assistant's published schedule: "A new stable version of Home
-    Assistant is released on the first Wednesday of every month"
-    (home-assistant.io/faq/release/). Measured against the eight 2026.x
-    releases, that rule was exact every time. It is computed here rather than
-    fetched, so a one-off rescheduled release would shift the estimate; the
-    ``broken_now`` level never depends on it. Returns ``None`` for anything
-    unparseable, and callers treat that as "no date opinion" rather than
-    guessing.
+    Home Assistant releases on the first Wednesday of every month
+    (home-assistant.io/faq/release/), which matched all eight 2026 releases
+    exactly. A rescheduled release would shift this; ``broken_now`` is decided
+    by version comparison instead, so it never depends on the estimate.
     """
     parts = release.split(".")
     if len(parts) < 2:
@@ -37,6 +40,29 @@ def release_estimated_date(release: str) -> date | None:
     except ValueError:
         return None
     return first + timedelta(days=(2 - first.weekday()) % 7)
+
+
+def describe_when(release: str, days: int | None) -> str:
+    """Human phrasing for a deadline: 'May 2027, about 8 months away'."""
+    when = release_estimated_date(release)
+    month = f"{MONTH_NAMES[when.month - 1]} {when.year}" if when else release
+    if days is None:
+        return month
+    if days < 0:
+        return f"{month}, already released"
+    if days == 0:
+        return f"{month}, today"
+    if days == 1:
+        return f"{month}, tomorrow"
+    if days < 45:
+        return f"{month}, about {days} days away"
+    months = round(days / 30.4)
+    if months < 12:
+        return f"{month}, about {months} months away"
+    years = days / 365.25
+    if years < 1.25:
+        return f"{month}, about a year away"
+    return f"{month}, about {years:.1f} years away".replace(".0 ", " ")
 
 
 def _index_by_domain(index: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -64,34 +90,17 @@ def build_report(
 ) -> dict[str, Any]:
     """Match installed custom integrations against the published index.
 
-    ``local_scan`` is the result of :func:`scan_installed`. Local findings
-    describe the exact installed bytes, so wherever the local scan reached a
-    verdict it **replaces** the index's: a domain the index never heard of that
-    parses clean becomes ``clean``, and an index finding disappears when the
-    installed copy no longer contains it. Only a domain the local scan could
-    not read falls back to the index, and if neither side knows it, it stays in
-    ``not_in_index`` with the local reason. A local ``clean`` reached with zero
-    matchable rules in play proves nothing and never overrides the index.
+    Local scan results replace the index's for the same domain, since they
+    describe the bytes actually installed. A domain the scan could not read
+    falls back to the index, and a local "clean" reached with no rules in play
+    never overrides an index finding.
 
-    ``current_version`` is the Home Assistant release this system runs, and
-    ``today`` the current date. Together they sort every finding into three
-    levels:
+    Findings are levelled as ``broken_now`` (running version has reached the
+    deadline, decided by version comparison so it is exact), ``imminent``
+    (release estimated within ``alert_window_days``) or ``upcoming``. Without
+    a version or a date everything degrades to ``upcoming``.
 
-    ``broken_now``  the running version has already reached the deadline. This
-                    is decided by version comparison alone -- never by a date
-                    estimate -- so it is exact.
-    ``imminent``    still ahead, but the release is estimated to land within
-                    ``alert_window_days``. Worth an alert of its own.
-    ``upcoming``    further out. Summarised in one group rather than alerted
-                    on individually, because a year-ahead deadline that cannot
-                    be dismissed just teaches people to ignore the panel.
-
-    Without a version or a date, findings degrade conservatively to
-    ``upcoming`` rather than guessing.
-
-    Returns a plain dict ready to become the sensor's state and attributes.
-    Unknown or malformed index payloads degrade to an empty report rather than
-    raising -- the caller decides whether that is an error.
+    A malformed index gives an empty report rather than raising.
     """
     rules = {
         rule["id"]: rule
@@ -113,7 +122,6 @@ def build_report(
     imminent: dict[str, dict[str, Any]] = {}
 
     def _days_until(release: str) -> int | None:
-        """Estimated days until ``release`` ships, or ``None`` if unknowable."""
         if today is None:
             return None
         when = release_estimated_date(release)
@@ -125,7 +133,6 @@ def build_report(
         if not release:
             return "upcoming"
         if current_version and not is_future(release, current_version):
-            # Exact: this system is already running the release that removed it.
             return "broken_now"
         days = _days_until(release)
         if days is not None and days <= alert_window_days:
@@ -171,9 +178,10 @@ def build_report(
                     "source": source,
                     "when": when,
                     "days_until": days,
+                    "due": describe_when(release, days),
                     "repository": (entry or {}).get("full_name", ""),
-                    # A local finding was matched against the installed bytes
-                    # themselves, so the scanned version *is* the installed one.
+                    # A local finding matched the installed bytes, so the
+                    # scanned version is the installed one.
                     "scanned_version": (
                         installed.get(domain, "")
                         if source == "local"
@@ -186,8 +194,7 @@ def build_report(
             )
 
     for domain in sorted(installed):
-        # Breakage Radar is reported on like anything else. Exempting the tool
-        # from its own check is how a check quietly stops being tested.
+        # Breakage Radar is reported on like anything else.
         entry = affected_by_domain.get(domain)
         index_findings = [
             f for f in (entry or {}).get("findings", []) if isinstance(f, dict)
@@ -207,8 +214,33 @@ def build_report(
             if local and local.get("reason"):
                 unknown_reasons[domain] = local["reason"]
 
-    details.sort(key=lambda d: (d["breaks_in"], d["domain"], d["file"], d["line"]))
+    details.sort(
+        key=lambda d: (parse_version(d["breaks_in"]), d["domain"], d["file"], d["line"])
+    )
     truncated = len(details) > MAX_DETAILS
+
+    # A wide window on a system with many affected integrations would other-
+    # wise raise a notification for each one. Keep the nearest few; the rest
+    # are in the summary, which carries every date anyway.
+    if len(imminent) > MAX_ALERT_CARDS:
+        nearest = sorted(imminent.items(), key=lambda item: item[1]["days"])
+        imminent = dict(nearest[:MAX_ALERT_CARDS])
+
+    schedule = []
+    for release, domains in sorted(
+        by_release.items(), key=lambda item: parse_version(item[0])
+    ):
+        days = _days_until(release)
+        schedule.append(
+            {
+                "release": release,
+                "due": describe_when(release, days),
+                "days_until": days,
+                "when": _when(release),
+                "domains": sorted(domains),
+                "count": len(domains),
+            }
+        )
 
     return {
         "affected_count": len(affected),
@@ -230,8 +262,7 @@ def build_report(
         "broken_now_count": len(broken_now),
         "imminent": imminent,
         "imminent_count": len(imminent),
-        # Affected domains with nothing urgent -- the ones the aggregate issue
-        # summarises rather than alerting on individually.
+        "schedule": schedule,
         "summarised_domains": sorted(
             set(affected) - set(broken_now) - set(imminent)
         ),

--- a/custom_components/breakage_radar/scanner.py
+++ b/custom_components/breakage_radar/scanner.py
@@ -1,9 +1,7 @@
-"""Running the rule matchers over installed integrations' own source.
+"""Runs the rule matchers over installed integrations' own source.
 
-Free of any ``homeassistant`` import; blocking I/O, so call from an executor.
-This is what gives forked, renamed and non-HACS integrations a real verdict
-instead of "not in the index" -- the matchers run over the exact installed
-bytes, which also removes any scanned-version/installed-version skew.
+Blocking I/O, so call from an executor. This is what gives forked, renamed and
+non-HACS integrations a real verdict instead of "not in the index".
 
 Problems are counted, never raised. A domain whose files cannot be parsed comes
 back ``unknown`` with a reason, and a truncated scan never reads as ``clean``:
@@ -20,20 +18,17 @@ from typing import Any
 from .discovery import IGNORED_DIRECTORIES, _manifest_domain
 from .rules_engine import ENGINE_VERSION, ScanStats, load_rules, match_source
 
-#: Directories the local scan never descends into -- the same vendored code the
-#: crawler's ``VENDOR_MARKERS`` excludes, so both sides judge the same files.
+#: Matches the crawler's VENDOR_MARKERS so both sides judge the same files.
 UNSCANNED_DIRECTORIES = IGNORED_DIRECTORIES | frozenset(
     {"site-packages", "node_modules", "vendor"}
 )
 
 
 def _rules_fingerprint(rules_payload: list[dict[str, Any]], current_version: str) -> str:
-    """A stable hash of everything that can change a scan's outcome.
+    """Cache key covering everything that can change a scan's outcome.
 
-    Folding in :data:`ENGINE_VERSION` and ``current_version`` means a rules
-    update, an engine semantics change *or* a Home Assistant upgrade (which can
-    move rules in or out of the future) all invalidate the cache, never leaving
-    stale findings behind.
+    A rules update, an engine change or a Home Assistant upgrade all invalidate
+    it, so a cached result can never outlive the rules that produced it.
     """
     digest = hashlib.sha256()
     digest.update(f"engine={ENGINE_VERSION};current={current_version};".encode())
@@ -42,11 +37,11 @@ def _rules_fingerprint(rules_payload: list[dict[str, Any]], current_version: str
 
 
 def _domain_python_files(domain_dir: str) -> tuple[list[tuple[str, str]], int]:
-    """``[(absolute_path, relative_posix_path)]`` for every ``*.py``, plus a
-    count of directories the walk could not enter.
+    """Every ``*.py`` as ``(absolute, relative)``, plus a count of directories
+    the walk could not enter.
 
-    ``__pycache__`` and symlinked directories are never descended into, so a
-    link pointing back up the tree cannot loop the scan or double-count files.
+    Symlinked subdirectories are skipped so a link pointing back up the tree
+    cannot loop the scan.
     """
     files: list[tuple[str, str]] = []
     unreadable_dirs = 0
@@ -85,11 +80,10 @@ def _scan_domain(
     max_files: int,
     max_bytes: int,
 ) -> dict[str, Any]:
-    """Run the matchers over one installed component directory. Never raises.
+    """Run the matchers over one component directory. Never raises.
 
-    ``directory_name`` is the on-disk name, which is what finding paths show;
-    the caller keys the result by the manifest-declared domain, which can
-    differ in a forked checkout.
+    ``directory_name`` is the on-disk name, used in finding paths. The caller
+    keys the result by the manifest domain, which can differ in a fork.
     """
     stats = ScanStats()
     findings: list[dict[str, Any]] = []
@@ -119,8 +113,8 @@ def _scan_domain(
     if findings:
         status = "affected"
     elif not rules:
-        # A scan with nothing to look for has proven nothing. Never let a
-        # degraded index launder every installation as clean.
+        # Nothing to look for means nothing was proven, so a degraded index
+        # can never launder an installation as clean.
         status = "unknown"
         reason = "the index shipped no matchable rules"
     elif unreadable_dirs:
@@ -138,8 +132,6 @@ def _scan_domain(
             "skipped by the size caps"
         )
     else:
-        # Zero findings with every file parsed -- including the trivial case of
-        # a component that ships no Python at all.
         status = "clean"
 
     return {
@@ -162,29 +154,17 @@ def scan_installed(
     max_bytes: int = 1_000_000,
     cache: dict[str, tuple[tuple[Any, ...], dict[str, Any]]] | None = None,
 ) -> dict[str, Any]:
-    """Scan every installed custom integration's own source with the index rules.
+    """Scan every installed integration's source against the index rules.
 
-    Blocking I/O -- call from an executor. This is what gives forked, renamed
-    and non-HACS integrations a real verdict instead of ``not_in_index``: the
-    matchers run over the exact installed bytes, so there is no
-    scanned-version/installed-version skew either.
+    Results are keyed by manifest domain, so a fork with a renamed directory
+    still lines up with discovery and the index. Rules are applied regardless
+    of tense; build_report levels them against the running version, since a
+    deadline that has already passed is the most urgent thing to report.
 
-    Every matchable rule is applied regardless of tense: a rule whose deadline
-    has already passed is the *most* urgent thing to report, so it is never
-    filtered out here -- :func:`build_report` classifies each finding as
-    ``upcoming`` or ``broken_now`` against the running version instead.
-    Results are keyed by the domain each component's manifest declares (the
-    same key :func:`discover_installed` uses), so a forked or renamed checkout
-    still matches up. A symlinked component directory is followed at the top
-    level -- the dev-checkout pattern -- while symlinked *subdirectories* are
-    still never descended into.
-
-    ``cache`` maps ``domain -> (signature, result)`` where the signature covers
-    the domain's file count, newest mtime, total size and the rules fingerprint;
-    a 12-hourly refresh therefore re-parses nothing that has not changed.
-    Problems are counted, never raised: a domain whose files cannot be parsed
-    comes back ``unknown`` with a reason, and a truncated scan never reads as
-    ``clean``.
+    A symlinked component directory is followed (the dev-checkout pattern),
+    its symlinked subdirectories are not. ``cache`` maps domain to
+    (signature, result), keyed on file count, newest mtime, size and the rules
+    fingerprint, so a refresh re-parses only what changed.
     """
     fingerprint = _rules_fingerprint(rules_payload, current_version)
     rules = [rule for rule in load_rules(rules_payload) if rule.matchable]

--- a/custom_components/breakage_radar/sensor.py
+++ b/custom_components/breakage_radar/sensor.py
@@ -12,10 +12,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    ATTR_BY_RELEASE,
     ATTR_DETAILS,
     ATTR_INDEX_GENERATED,
+    ATTR_SCHEDULE,
     DOMAIN,
+    MAX_SENSOR_FINDINGS,
     NAME,
 )
 from .coordinator import BreakageRadarCoordinator
@@ -64,28 +65,46 @@ class BreakageRadarSensor(CoordinatorEntity[BreakageRadarCoordinator], SensorEnt
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
+        """A compact summary of the report.
+
+        Home Assistant's recorder drops state attributes over 16 KB, and the
+        full finding list went past that on a system with nine affected
+        integrations. Each finding is trimmed to the fields worth templating
+        on; the messages, links and versions are in the downloadable
+        diagnostics instead.
+        """
         data = self.coordinator.data or {}
+        findings = [
+            {
+                "domain": detail["domain"],
+                "breaks_in": detail["breaks_in"],
+                "when": detail["when"],
+                "file": detail["file"],
+                "line": detail["line"],
+                "confidence": detail["confidence"],
+                "rule_id": detail["rule_id"],
+            }
+            for detail in data.get("details", [])[:MAX_SENSOR_FINDINGS]
+        ]
         attributes: dict[str, Any] = {
-            ATTR_BY_RELEASE: data.get("by_release", {}),
-            ATTR_DETAILS: data.get("details", []),
+            ATTR_SCHEDULE: data.get("schedule", []),
+            ATTR_DETAILS: findings,
             ATTR_INDEX_GENERATED: data.get("index_generated_utc", ""),
             "affected_domains": data.get("affected_domains", []),
-            "schedule": data.get("schedule", []),
             "broken_now": data.get("broken_now", {}),
             "broken_now_count": data.get("broken_now_count", 0),
             "imminent": data.get("imminent", {}),
             "imminent_count": data.get("imminent_count", 0),
-            "summarised_domains": data.get("summarised_domains", []),
+            "earliest_release": data.get("earliest_release"),
             "alert_window_days": data.get("alert_window_days", 0),
             "total_findings": data.get("total_findings", 0),
-            "details_truncated": data.get("details_truncated", False),
+            "details_truncated": data.get("total_findings", 0) > len(findings),
             "installed_count": data.get("installed_count", 0),
-            "not_in_index": data.get("not_in_index", []),
-            "not_in_index_reasons": data.get("not_in_index_reasons", {}),
+            "clean_count": len(data.get("clean_domains", [])),
+            "not_analysed": data.get("not_in_index", []),
             "files_scanned": data.get("files_scanned", 0),
             "unparsed_files": data.get("unparsed_files", 0),
             "skipped_files": data.get("skipped_files", 0),
-            "earliest_release": data.get("earliest_release"),
             "index_core_version": data.get("index_core_version", ""),
             "index_url": self.coordinator.index_url,
         }

--- a/custom_components/breakage_radar/sensor.py
+++ b/custom_components/breakage_radar/sensor.py
@@ -70,6 +70,7 @@ class BreakageRadarSensor(CoordinatorEntity[BreakageRadarCoordinator], SensorEnt
             ATTR_DETAILS: data.get("details", []),
             ATTR_INDEX_GENERATED: data.get("index_generated_utc", ""),
             "affected_domains": data.get("affected_domains", []),
+            "schedule": data.get("schedule", []),
             "broken_now": data.get("broken_now", {}),
             "broken_now_count": data.get("broken_now_count", 0),
             "imminent": data.get("imminent", {}),

--- a/custom_components/breakage_radar/strings.json
+++ b/custom_components/breakage_radar/strings.json
@@ -11,6 +11,31 @@
       "single_instance_allowed": "Breakage Radar is already set up. Only one instance is needed."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Breakage Radar options",
+        "description": "Integrations breaking inside the alert window get their own repair notification. Everything further out is listed together in one summary, so a deadline a year away doesn't sit in your notifications for months.",
+        "data": {
+          "alert_window_days": "Alert me this far ahead"
+        },
+        "data_description": {
+          "alert_window_days": "Home Assistant releases monthly, so 90 days is about three releases of warning."
+        }
+      }
+    }
+  },
+  "selector": {
+    "alert_window_days": {
+      "options": {
+        "30": "30 days (one release)",
+        "60": "60 days (two releases)",
+        "90": "90 days (three releases)",
+        "180": "6 months",
+        "365": "1 year"
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "affected": {
@@ -20,16 +45,16 @@
   },
   "issues": {
     "integrations_affected": {
-      "title": "{count} custom integration(s) will break in a later Home Assistant release",
-      "description": "Breakage Radar found deprecated Home Assistant APIs in these installed custom integrations: {integrations}.\n\nBy release: {releases}. The first of these deadlines is Home Assistant {earliest}. Anything breaking within the next month gets its own issue instead of being listed here.\n\nThis cannot be fixed from here — the code lives in the integration's own repository. Open the details on `sensor.breakage_radar_affected` to see the exact file and line, then raise it with the integration's maintainer or plan a replacement before the deadline."
+      "title": "{count} custom integration(s) will break in a future Home Assistant release",
+      "description": "These installed custom integrations use Home Assistant APIs that are scheduled for removal. Nothing breaks today, and the first deadline is {earliest_due}.\n\n**What breaks, and when:**\n\n```\n{schedule}\n```\n\nEach one has to be fixed by whoever maintains it, so the useful next step is to check the integration's repository for a newer release, or raise it with the author while there is still time. `sensor.breakage_radar_affected` lists the exact file and line for every finding.\n\nAnything breaking within {window} days gets its own notification instead of being listed here. You can change that in the integration's options."
     },
     "integration_imminent": {
-      "title": "{domain} breaks in about {days} day(s), in Home Assistant {release}",
-      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due in about {days} day(s) (Home Assistant releases on the first Wednesday of every month).\n\nCheck the integration's repository for a release that fixes it before you upgrade. The exact file and line are in the details on `sensor.breakage_radar_affected`. This issue clears itself once the integration no longer uses the removed API."
+      "title": "{domain} breaks in about {days} day(s)",
+      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\nCheck the integration's repository for a newer release that fixes it, and if there isn't one, consider raising an issue there or finding a replacement before you upgrade.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
     },
     "integration_broken": {
       "title": "{domain} uses an API that was removed in Home Assistant {release}",
-      "description": "This system is running Home Assistant {release} or later, so the deprecated API that Breakage Radar found in `{domain}` is already gone — the integration is likely failing right now.\n\nCheck the integration's repository for an updated release, or replace it. The exact file and line are in the details on `sensor.breakage_radar_affected`. This issue clears itself once an updated version no longer contains the removed API."
+      "description": "This system is running Home Assistant {release} or later, and `{domain}` still uses an API that release removed. It is most likely failing right now.\n\nCheck the integration's repository for an update. If there isn't one, the integration will need replacing, or you can raise it with the author.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
     }
   }
 }

--- a/custom_components/breakage_radar/strings.json
+++ b/custom_components/breakage_radar/strings.json
@@ -20,7 +20,7 @@
           "alert_window_days": "Alert me this far ahead"
         },
         "data_description": {
-          "alert_window_days": "Home Assistant releases monthly, so 90 days is about three releases of warning."
+          "alert_window_days": "Home Assistant releases once a month, on the first Wednesday, so each 30 days is roughly one release of warning."
         }
       }
     }
@@ -45,12 +45,12 @@
   },
   "issues": {
     "integrations_affected": {
-      "title": "{count} custom integration(s) will break in a future Home Assistant release",
-      "description": "These installed custom integrations use Home Assistant APIs that are scheduled for removal. Nothing breaks today, and the first deadline is {earliest_due}.\n\n**What breaks, and when:**\n\n```\n{schedule}\n```\n\nEach one has to be fixed by whoever maintains it, so the useful next step is to check the integration's repository for a newer release, or raise it with the author while there is still time. `sensor.breakage_radar_affected` lists the exact file and line for every finding.\n\nAnything breaking within {window} days gets its own notification instead of being listed here. You can change that in the integration's options."
+      "title": "{count} custom {noun} will break in a future release",
+      "description": "{count} installed custom {noun} {verb} Home Assistant APIs that are scheduled for removal. Nothing breaks today. The first deadline is {earliest_due}.\n\n**What breaks, and when**\n\n{schedule}\n\nEach one has to be fixed by whoever maintains it. The useful next step is to check the integration's repository for a newer release, or raise it with the author while there is still time. `sensor.breakage_radar_affected` lists the exact file and line for every finding.\n\nAnything breaking within {window} days gets its own notification instead of being listed here. You can change that in this integration's options."
     },
     "integration_imminent": {
-      "title": "{domain} breaks in about {days} day(s)",
-      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\nCheck the integration's repository for a newer release that fixes it, and if there isn't one, consider raising an issue there or finding a replacement before you upgrade.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
+      "title": "{domain} breaks in about {days} {day_word}",
+      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\nCheck the integration's repository for a newer release that fixes it. If there isn't one, consider raising an issue there, or finding a replacement before you upgrade.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
     },
     "integration_broken": {
       "title": "{domain} uses an API that was removed in Home Assistant {release}",

--- a/custom_components/breakage_radar/strings.json
+++ b/custom_components/breakage_radar/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Breakage Radar",
-        "description": "Breakage Radar compares the custom integrations installed on this system against a public index of Home Assistant APIs that are scheduled for removal, and tells you which release removes them.\n\nThe index is downloaded from {index_url} every 12 hours. Nothing is uploaded and no account is needed."
+        "description": "Home Assistant announces API removals about a year ahead. Custom integrations often don't get updated in time, and the warning only ever reaches your log file.\n\nBreakage Radar checks the custom integrations installed here against a public index of those removals, and against your own installed code, so you find out before an upgrade breaks something.\n\nThe index is downloaded from {index_url} every 12 hours. Nothing is uploaded and no account is needed."
       }
     },
     "abort": {
@@ -15,7 +15,7 @@
     "step": {
       "init": {
         "title": "Breakage Radar options",
-        "description": "Integrations breaking inside the alert window get their own repair notification. Everything further out is listed together in one summary, so a deadline a year away doesn't sit in your notifications for months.",
+        "description": "An integration breaking inside the alert window gets its own notification. Everything further out is listed together in one summary, so a deadline a year away doesn't sit in your notifications for months.",
         "data": {
           "alert_window_days": "Alert me this far ahead"
         },
@@ -28,9 +28,9 @@
   "selector": {
     "alert_window_days": {
       "options": {
-        "30": "30 days (one release)",
-        "60": "60 days (two releases)",
-        "90": "90 days (three releases)",
+        "30": "30 days (about one release)",
+        "60": "60 days (about two releases)",
+        "90": "90 days (about three releases)",
         "180": "6 months",
         "365": "1 year"
       }
@@ -39,22 +39,22 @@
   "entity": {
     "sensor": {
       "affected": {
-        "name": "Affected"
+        "name": "Affected integrations"
       }
     }
   },
   "issues": {
     "integrations_affected": {
       "title": "{count} custom {noun} will break in a future release",
-      "description": "{count} installed custom {noun} {verb} Home Assistant APIs that are scheduled for removal. Nothing breaks today. The first deadline is {earliest_due}.\n\n**What breaks, and when**\n\n{schedule}\n\nEach one has to be fixed by whoever maintains it. The useful next step is to check the integration's repository for a newer release, or raise it with the author while there is still time. `sensor.breakage_radar_affected` lists the exact file and line for every finding.\n\nAnything breaking within {window} days gets its own notification instead of being listed here. You can change that in this integration's options."
+      "description": "{count} installed custom {noun} {verb} Home Assistant APIs that are scheduled for removal. Nothing is broken today. The first deadline is {earliest_due}.\n\n**What breaks, and when**\n\n{schedule}\n\nEach one has to be fixed by whoever maintains it, so the useful next step is to check those repositories for a newer release. Anything breaking within {window} days gets its own notification with a direct link, which you can change in this integration's options.\n\nThe exact file and line for every finding is on `sensor.breakage_radar_affected`, and the full report is under **Download diagnostics** on this integration's page.\n\n[Look up any integration on the public board]({board_url})"
     },
     "integration_imminent": {
       "title": "{domain} breaks in about {days} {day_word}",
-      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\nCheck the integration's repository for a newer release that fixes it. If there isn't one, consider raising an issue there, or finding a replacement before you upgrade.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
+      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\n{where}\n\nIf no fix arrives before then, you can stay on your current Home Assistant version or replace the integration. This notification clears itself once `{domain}` no longer uses the removed API."
     },
     "integration_broken": {
-      "title": "{domain} uses an API that was removed in Home Assistant {release}",
-      "description": "This system is running Home Assistant {release} or later, and `{domain}` still uses an API that release removed. It is most likely failing right now.\n\nCheck the integration's repository for an update. If there isn't one, the integration will need replacing, or you can raise it with the author.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
+      "title": "{domain} uses an API that Home Assistant {release} removed",
+      "description": "This system runs Home Assistant {release} or later, and `{domain}` still uses an API that release removed, so it is most likely failing right now.\n\n{where}\n\nThis notification clears itself once `{domain}` no longer uses the removed API. The exact file and line are on `sensor.breakage_radar_affected`."
     }
   }
 }

--- a/custom_components/breakage_radar/translations/en.json
+++ b/custom_components/breakage_radar/translations/en.json
@@ -11,6 +11,31 @@
       "single_instance_allowed": "Breakage Radar is already set up. Only one instance is needed."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Breakage Radar options",
+        "description": "Integrations breaking inside the alert window get their own repair notification. Everything further out is listed together in one summary, so a deadline a year away doesn't sit in your notifications for months.",
+        "data": {
+          "alert_window_days": "Alert me this far ahead"
+        },
+        "data_description": {
+          "alert_window_days": "Home Assistant releases monthly, so 90 days is about three releases of warning."
+        }
+      }
+    }
+  },
+  "selector": {
+    "alert_window_days": {
+      "options": {
+        "30": "30 days (one release)",
+        "60": "60 days (two releases)",
+        "90": "90 days (three releases)",
+        "180": "6 months",
+        "365": "1 year"
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "affected": {
@@ -20,16 +45,16 @@
   },
   "issues": {
     "integrations_affected": {
-      "title": "{count} custom integration(s) will break in a later Home Assistant release",
-      "description": "Breakage Radar found deprecated Home Assistant APIs in these installed custom integrations: {integrations}.\n\nBy release: {releases}. The first of these deadlines is Home Assistant {earliest}. Anything breaking within the next month gets its own issue instead of being listed here.\n\nThis cannot be fixed from here — the code lives in the integration's own repository. Open the details on `sensor.breakage_radar_affected` to see the exact file and line, then raise it with the integration's maintainer or plan a replacement before the deadline."
+      "title": "{count} custom integration(s) will break in a future Home Assistant release",
+      "description": "These installed custom integrations use Home Assistant APIs that are scheduled for removal. Nothing breaks today, and the first deadline is {earliest_due}.\n\n**What breaks, and when:**\n\n```\n{schedule}\n```\n\nEach one has to be fixed by whoever maintains it, so the useful next step is to check the integration's repository for a newer release, or raise it with the author while there is still time. `sensor.breakage_radar_affected` lists the exact file and line for every finding.\n\nAnything breaking within {window} days gets its own notification instead of being listed here. You can change that in the integration's options."
     },
     "integration_imminent": {
-      "title": "{domain} breaks in about {days} day(s), in Home Assistant {release}",
-      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due in about {days} day(s) (Home Assistant releases on the first Wednesday of every month).\n\nCheck the integration's repository for a release that fixes it before you upgrade. The exact file and line are in the details on `sensor.breakage_radar_affected`. This issue clears itself once the integration no longer uses the removed API."
+      "title": "{domain} breaks in about {days} day(s)",
+      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\nCheck the integration's repository for a newer release that fixes it, and if there isn't one, consider raising an issue there or finding a replacement before you upgrade.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
     },
     "integration_broken": {
       "title": "{domain} uses an API that was removed in Home Assistant {release}",
-      "description": "This system is running Home Assistant {release} or later, so the deprecated API that Breakage Radar found in `{domain}` is already gone — the integration is likely failing right now.\n\nCheck the integration's repository for an updated release, or replace it. The exact file and line are in the details on `sensor.breakage_radar_affected`. This issue clears itself once an updated version no longer contains the removed API."
+      "description": "This system is running Home Assistant {release} or later, and `{domain}` still uses an API that release removed. It is most likely failing right now.\n\nCheck the integration's repository for an update. If there isn't one, the integration will need replacing, or you can raise it with the author.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
     }
   }
 }

--- a/custom_components/breakage_radar/translations/en.json
+++ b/custom_components/breakage_radar/translations/en.json
@@ -20,7 +20,7 @@
           "alert_window_days": "Alert me this far ahead"
         },
         "data_description": {
-          "alert_window_days": "Home Assistant releases monthly, so 90 days is about three releases of warning."
+          "alert_window_days": "Home Assistant releases once a month, on the first Wednesday, so each 30 days is roughly one release of warning."
         }
       }
     }
@@ -45,12 +45,12 @@
   },
   "issues": {
     "integrations_affected": {
-      "title": "{count} custom integration(s) will break in a future Home Assistant release",
-      "description": "These installed custom integrations use Home Assistant APIs that are scheduled for removal. Nothing breaks today, and the first deadline is {earliest_due}.\n\n**What breaks, and when:**\n\n```\n{schedule}\n```\n\nEach one has to be fixed by whoever maintains it, so the useful next step is to check the integration's repository for a newer release, or raise it with the author while there is still time. `sensor.breakage_radar_affected` lists the exact file and line for every finding.\n\nAnything breaking within {window} days gets its own notification instead of being listed here. You can change that in the integration's options."
+      "title": "{count} custom {noun} will break in a future release",
+      "description": "{count} installed custom {noun} {verb} Home Assistant APIs that are scheduled for removal. Nothing breaks today. The first deadline is {earliest_due}.\n\n**What breaks, and when**\n\n{schedule}\n\nEach one has to be fixed by whoever maintains it. The useful next step is to check the integration's repository for a newer release, or raise it with the author while there is still time. `sensor.breakage_radar_affected` lists the exact file and line for every finding.\n\nAnything breaking within {window} days gets its own notification instead of being listed here. You can change that in this integration's options."
     },
     "integration_imminent": {
-      "title": "{domain} breaks in about {days} day(s)",
-      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\nCheck the integration's repository for a newer release that fixes it, and if there isn't one, consider raising an issue there or finding a replacement before you upgrade.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
+      "title": "{domain} breaks in about {days} {day_word}",
+      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\nCheck the integration's repository for a newer release that fixes it. If there isn't one, consider raising an issue there, or finding a replacement before you upgrade.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
     },
     "integration_broken": {
       "title": "{domain} uses an API that was removed in Home Assistant {release}",

--- a/custom_components/breakage_radar/translations/en.json
+++ b/custom_components/breakage_radar/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Breakage Radar",
-        "description": "Breakage Radar compares the custom integrations installed on this system against a public index of Home Assistant APIs that are scheduled for removal, and tells you which release removes them.\n\nThe index is downloaded from {index_url} every 12 hours. Nothing is uploaded and no account is needed."
+        "description": "Home Assistant announces API removals about a year ahead. Custom integrations often don't get updated in time, and the warning only ever reaches your log file.\n\nBreakage Radar checks the custom integrations installed here against a public index of those removals, and against your own installed code, so you find out before an upgrade breaks something.\n\nThe index is downloaded from {index_url} every 12 hours. Nothing is uploaded and no account is needed."
       }
     },
     "abort": {
@@ -15,7 +15,7 @@
     "step": {
       "init": {
         "title": "Breakage Radar options",
-        "description": "Integrations breaking inside the alert window get their own repair notification. Everything further out is listed together in one summary, so a deadline a year away doesn't sit in your notifications for months.",
+        "description": "An integration breaking inside the alert window gets its own notification. Everything further out is listed together in one summary, so a deadline a year away doesn't sit in your notifications for months.",
         "data": {
           "alert_window_days": "Alert me this far ahead"
         },
@@ -28,9 +28,9 @@
   "selector": {
     "alert_window_days": {
       "options": {
-        "30": "30 days (one release)",
-        "60": "60 days (two releases)",
-        "90": "90 days (three releases)",
+        "30": "30 days (about one release)",
+        "60": "60 days (about two releases)",
+        "90": "90 days (about three releases)",
         "180": "6 months",
         "365": "1 year"
       }
@@ -39,22 +39,22 @@
   "entity": {
     "sensor": {
       "affected": {
-        "name": "Affected"
+        "name": "Affected integrations"
       }
     }
   },
   "issues": {
     "integrations_affected": {
       "title": "{count} custom {noun} will break in a future release",
-      "description": "{count} installed custom {noun} {verb} Home Assistant APIs that are scheduled for removal. Nothing breaks today. The first deadline is {earliest_due}.\n\n**What breaks, and when**\n\n{schedule}\n\nEach one has to be fixed by whoever maintains it. The useful next step is to check the integration's repository for a newer release, or raise it with the author while there is still time. `sensor.breakage_radar_affected` lists the exact file and line for every finding.\n\nAnything breaking within {window} days gets its own notification instead of being listed here. You can change that in this integration's options."
+      "description": "{count} installed custom {noun} {verb} Home Assistant APIs that are scheduled for removal. Nothing is broken today. The first deadline is {earliest_due}.\n\n**What breaks, and when**\n\n{schedule}\n\nEach one has to be fixed by whoever maintains it, so the useful next step is to check those repositories for a newer release. Anything breaking within {window} days gets its own notification with a direct link, which you can change in this integration's options.\n\nThe exact file and line for every finding is on `sensor.breakage_radar_affected`, and the full report is under **Download diagnostics** on this integration's page.\n\n[Look up any integration on the public board]({board_url})"
     },
     "integration_imminent": {
       "title": "{domain} breaks in about {days} {day_word}",
-      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\nCheck the integration's repository for a newer release that fixes it. If there isn't one, consider raising an issue there, or finding a replacement before you upgrade.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
+      "description": "Home Assistant {release} removes an API that `{domain}` still uses, and that release is due {due}.\n\n{where}\n\nIf no fix arrives before then, you can stay on your current Home Assistant version or replace the integration. This notification clears itself once `{domain}` no longer uses the removed API."
     },
     "integration_broken": {
-      "title": "{domain} uses an API that was removed in Home Assistant {release}",
-      "description": "This system is running Home Assistant {release} or later, and `{domain}` still uses an API that release removed. It is most likely failing right now.\n\nCheck the integration's repository for an update. If there isn't one, the integration will need replacing, or you can raise it with the author.\n\nThis notification clears itself once the integration no longer uses the removed API. The exact file and line are in the details on `sensor.breakage_radar_affected`."
+      "title": "{domain} uses an API that Home Assistant {release} removed",
+      "description": "This system runs Home Assistant {release} or later, and `{domain}` still uses an API that release removed, so it is most likely failing right now.\n\n{where}\n\nThis notification clears itself once `{domain}` no longer uses the removed API. The exact file and line are on `sensor.breakage_radar_affected`."
     }
   }
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "Breakage Radar",
   "content_in_root": false,
   "render_readme": true,
-  "homeassistant": "2024.6.0",
+  "homeassistant": "2024.11.0",
   "zip_release": false
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-breakage-radar"
-version = "1.2.2"
+version = "1.3.0"
 description = "Find out which of your Home Assistant custom integrations stop working, and in which future release."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,17 +49,85 @@ def _install_homeassistant_stubs() -> None:
 
     class ConfigEntry:  # noqa: D101
         entry_id = "test-entry"
+        options: dict = {}
 
     class ConfigFlowResult(dict):  # noqa: D101
         pass
 
-    class ConfigFlow:  # noqa: D101
+    class _FlowBase:
+        """Enough of HA's flow API to drive a flow in a test."""
+
+        async def async_set_unique_id(self, unique_id):
+            self._unique_id = unique_id
+
+        def _abort_if_unique_id_configured(self):
+            return None
+
+        def async_show_form(self, **kwargs):
+            return ConfigFlowResult(type="form", **kwargs)
+
+        def async_create_entry(self, **kwargs):
+            return ConfigFlowResult(type="create_entry", **kwargs)
+
+    class ConfigFlow(_FlowBase):  # noqa: D101
         def __init_subclass__(cls, **kwargs):
             super().__init_subclass__()
+
+    class OptionsFlow(_FlowBase):  # noqa: D101
+        config_entry = ConfigEntry()
 
     config_entries.ConfigEntry = ConfigEntry
     config_entries.ConfigFlow = ConfigFlow
     config_entries.ConfigFlowResult = ConfigFlowResult
+    config_entries.OptionsFlow = OptionsFlow
+
+    selector = module("homeassistant.helpers.selector")
+
+    class SelectSelectorMode:  # noqa: D101
+        DROPDOWN = "dropdown"
+        LIST = "list"
+
+    class SelectSelectorConfig:  # noqa: D101
+        def __init__(self, options=None, mode=None, translation_key=None, **kwargs):
+            self.options = options or []
+            self.mode = mode
+            self.translation_key = translation_key
+
+    class SelectSelector:  # noqa: D101
+        def __init__(self, config):
+            self.config = config
+
+        def __call__(self, value):
+            return value
+
+    selector.SelectSelector = SelectSelector
+    selector.SelectSelectorConfig = SelectSelectorConfig
+    selector.SelectSelectorMode = SelectSelectorMode
+
+    try:
+        import voluptuous  # noqa: F401
+    except ImportError:
+        # Home Assistant always ships voluptuous; a bare CI runner does not.
+        vol = module("voluptuous")
+
+        class Marker:
+            def __init__(self, schema, default=None, description=None):
+                self.schema = schema
+                self.default = default
+
+            def __hash__(self):
+                return hash(self.schema)
+
+            def __eq__(self, other):
+                return self.schema == getattr(other, "schema", other)
+
+        class Schema:
+            def __init__(self, schema):
+                self.schema = schema
+
+        vol.Schema = Schema
+        vol.Required = Marker
+        vol.Optional = Marker
 
     const = module("homeassistant.const")
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -47,6 +47,7 @@ def test_options_flow_offers_the_documented_choices():
 
     selector = form["data_schema"].schema[marker]
     assert selector.config.options == [str(d) for d in ALERT_WINDOW_CHOICES]
+    assert ALERT_WINDOW_DAYS in ALERT_WINDOW_CHOICES, "default must be selectable"
     assert selector.config.translation_key == CONF_ALERT_WINDOW_DAYS
 
 
@@ -69,10 +70,6 @@ def test_every_offered_choice_has_a_translated_label(repo_root):
     labels = strings["selector"][CONF_ALERT_WINDOW_DAYS]["options"]
     assert set(labels) == {str(days) for days in ALERT_WINDOW_CHOICES}
     assert all(label.strip() for label in labels.values())
-
-
-def test_the_default_window_is_one_of_the_choices():
-    assert ALERT_WINDOW_DAYS in ALERT_WINDOW_CHOICES
 
 
 def test_strings_reference_the_real_entity_id(repo_root):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -73,3 +73,44 @@ def test_every_offered_choice_has_a_translated_label(repo_root):
 
 def test_the_default_window_is_one_of_the_choices():
     assert ALERT_WINDOW_DAYS in ALERT_WINDOW_CHOICES
+
+
+def test_strings_reference_the_real_entity_id(repo_root):
+    """The cards tell people where to look, so the id has to be right."""
+    from custom_components.breakage_radar.const import DOMAIN
+
+    base = repo_root / "custom_components" / "breakage_radar"
+    strings = (base / "strings.json").read_text(encoding="utf-8")
+    sensor_src = (base / "sensor.py").read_text(encoding="utf-8")
+
+    assert 'f"sensor.{DOMAIN}_affected"' in sensor_src
+    real = f"sensor.{DOMAIN}_affected"
+    assert f"`{real}`" in strings
+    # No reference to an entity id that does not exist.
+    for line in strings.splitlines():
+        for token in line.split("`"):
+            if token.startswith("sensor."):
+                assert token == real, f"unknown entity id in strings.json: {token}"
+
+
+def test_every_placeholder_in_strings_is_supplied(repo_root):
+    """A missing placeholder renders as a literal {name} in the card."""
+    import json
+    import re
+
+    from custom_components.breakage_radar.repairs import (
+        BROKEN_ISSUE_PREFIX,
+        IMMINENT_ISSUE_PREFIX,
+    )
+
+    base = repo_root / "custom_components" / "breakage_radar"
+    strings = json.loads((base / "strings.json").read_text(encoding="utf-8"))
+    repairs_src = (base / "repairs.py").read_text(encoding="utf-8")
+
+    for key, issue in strings["issues"].items():
+        used = set(re.findall(r"\{(\w+)\}", issue["title"] + issue["description"]))
+        for name in used:
+            assert f'"{name}"' in repairs_src, (
+                f"issue {key} uses {{{name}}} but repairs.py never supplies it"
+            )
+    assert BROKEN_ISSUE_PREFIX and IMMINENT_ISSUE_PREFIX

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,75 @@
+"""The config flow and the options flow.
+
+Nothing imported config_flow.py before, so a broken import there would only
+have shown up when a user tried to add the integration. That is how issue #1
+reached someone's system, so these tests exist mostly to make sure the module
+loads and both flows actually run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from custom_components.breakage_radar.config_flow import (
+    BreakageRadarConfigFlow,
+    BreakageRadarOptionsFlow,
+)
+from custom_components.breakage_radar.const import (
+    ALERT_WINDOW_CHOICES,
+    ALERT_WINDOW_DAYS,
+    CONF_ALERT_WINDOW_DAYS,
+    NAME,
+)
+
+
+def test_config_flow_shows_a_confirmation_then_creates_one_entry():
+    flow = BreakageRadarConfigFlow()
+
+    form = asyncio.run(flow.async_step_user())
+    assert form["type"] == "form"
+    assert form["step_id"] == "user"
+    assert "index_url" in form["description_placeholders"]
+
+    created = asyncio.run(flow.async_step_user({}))
+    assert created["type"] == "create_entry"
+    assert created["title"] == NAME
+
+
+def test_options_flow_offers_the_documented_choices():
+    flow = BreakageRadarOptionsFlow()
+    form = asyncio.run(flow.async_step_init())
+
+    assert form["type"] == "form"
+    marker = next(iter(form["data_schema"].schema))
+    assert marker.schema == CONF_ALERT_WINDOW_DAYS
+    assert marker.default == str(ALERT_WINDOW_DAYS)
+
+    selector = form["data_schema"].schema[marker]
+    assert selector.config.options == [str(d) for d in ALERT_WINDOW_CHOICES]
+    assert selector.config.translation_key == CONF_ALERT_WINDOW_DAYS
+
+
+def test_options_flow_stores_the_window_as_an_int():
+    flow = BreakageRadarOptionsFlow()
+    result = asyncio.run(flow.async_step_init({CONF_ALERT_WINDOW_DAYS: "180"}))
+
+    assert result["type"] == "create_entry"
+    # A selector hands back a string; the coordinator does date maths with it.
+    assert result["data"] == {CONF_ALERT_WINDOW_DAYS: 180}
+    assert isinstance(result["data"][CONF_ALERT_WINDOW_DAYS], int)
+
+
+def test_every_offered_choice_has_a_translated_label(repo_root):
+    strings = json.loads(
+        (repo_root / "custom_components" / "breakage_radar" / "strings.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    labels = strings["selector"][CONF_ALERT_WINDOW_DAYS]["options"]
+    assert set(labels) == {str(days) for days in ALERT_WINDOW_CHOICES}
+    assert all(label.strip() for label in labels.values())
+
+
+def test_the_default_window_is_one_of_the_choices():
+    assert ALERT_WINDOW_DAYS in ALERT_WINDOW_CHOICES

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -124,6 +124,7 @@ def test_worked_example_report(sample_index):
             "source": "index",
             "when": "upcoming",
             "days_until": None,
+            "due": "May 2027",
             "repository": "example/fixture-tracker",
             "scanned_version": "0.1.0",
             "installed_version": "0.1.0",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,7 @@ import re
 
 import pytest
 
-from custom_components.breakage_radar.const import ATTR_BY_RELEASE, MAX_DETAILS
+from custom_components.breakage_radar.const import ATTR_SCHEDULE, MAX_DETAILS
 from custom_components.breakage_radar.discovery import discover_installed
 from custom_components.breakage_radar.report import build_report, validate_index
 from custom_components.breakage_radar.sensor import BreakageRadarSensor
@@ -112,7 +112,8 @@ def test_discover_installed_survives_a_broken_manifest(tmp_path):
 def test_worked_example_report(sample_index):
     report = build_report(sample_index, {"fixture_tracker": "0.1.0"})
     assert report["affected_count"] == 1
-    assert report["by_release"] == {"2027.5": ["fixture_tracker"]}
+    assert [g["release"] for g in report["schedule"]] == ["2027.5"]
+    assert report["schedule"][0]["domains"] == ["fixture_tracker"]
     assert report["details"] == [
         {
             "domain": "fixture_tracker",
@@ -156,7 +157,7 @@ def test_clean_and_unknown_domains_are_separated(sample_index):
 def test_empty_installation_gives_an_empty_report(sample_index):
     report = build_report(sample_index, {})
     assert report["affected_count"] == 0
-    assert report["by_release"] == {}
+    assert report["schedule"] == []
     assert report["earliest_release"] is None
 
 
@@ -210,11 +211,11 @@ def test_sensor_state_and_attributes(sample_index):
     sensor = BreakageRadarSensor(FakeCoordinator(report))
 
     assert sensor.native_value == 1
-    assert sensor.extra_state_attributes[ATTR_BY_RELEASE] == {
-        "2027.5": ["fixture_tracker"]
-    }
+    schedule = sensor.extra_state_attributes[ATTR_SCHEDULE]
+    assert [g["release"] for g in schedule] == ["2027.5"]
+    assert schedule[0]["domains"] == ["fixture_tracker"]
     assert sensor.entity_id == "sensor.breakage_radar_affected"
-    assert sensor.extra_state_attributes["details"][0]["line"] == 12
+    assert sensor.extra_state_attributes["findings"][0]["line"] == 12
     assert sensor.extra_state_attributes["index_generated_utc"] == "2026-08-08T09:00:00Z"
     assert "last_error" not in sensor.extra_state_attributes
 
@@ -233,7 +234,7 @@ def test_sensor_is_unavailable_and_keeps_the_last_report_on_failure(sample_index
 def test_sensor_with_no_data_yet_has_no_state():
     sensor = BreakageRadarSensor(FakeCoordinator(None))
     assert sensor.native_value is None
-    assert sensor.extra_state_attributes[ATTR_BY_RELEASE] == {}
+    assert sensor.extra_state_attributes[ATTR_SCHEDULE] == []
 
 
 # --------------------------------------------------------------------------- #
@@ -283,10 +284,10 @@ def test_broken_now_gets_its_own_error_issue_and_clears_on_recovery(sample_index
     broken_key = (DOMAIN, "broken_now_fixture_tracker")
     assert broken_key in ir.created
     assert ir.created[broken_key]["severity"] == ir.IssueSeverity.ERROR
-    assert ir.created[broken_key]["translation_placeholders"] == {
-        "domain": "fixture_tracker",
-        "release": "2027.5",
-    }
+    placeholders = ir.created[broken_key]["translation_placeholders"]
+    assert placeholders["domain"] == "fixture_tracker"
+    assert placeholders["release"] == "2027.5"
+    assert "example/fixture-tracker" in placeholders["where"]
     # Promoted to its own card, so it is no longer in the summary -- and with
     # nothing left to summarise the aggregate issue goes away entirely.
     assert report["summarised_domains"] == []

--- a/tests/test_levels.py
+++ b/tests/test_levels.py
@@ -202,13 +202,11 @@ def test_imminent_raises_its_own_warning_issue_and_steps_down_again(sample_index
     key = (DOMAIN, "imminent_fixture_tracker")
     assert key in ir.created
     assert ir.created[key]["severity"] == ir.IssueSeverity.WARNING
-    assert ir.created[key]["translation_placeholders"] == {
-        "domain": "fixture_tracker",
-        "release": "2027.5",
-        "days": "24",
-        "day_word": "days",
-        "due": "May 2027, about 24 days away",
-    }
+    placeholders = ir.created[key]["translation_placeholders"]
+    assert placeholders["days"] == "24"
+    assert placeholders["day_word"] == "days"
+    assert placeholders["due"] == "May 2027, about 24 days away"
+    assert "example/fixture-tracker" in placeholders["where"]
     # Nothing left over, so no summary issue.
     assert (DOMAIN, ISSUE_ID) not in ir.created
 

--- a/tests/test_levels.py
+++ b/tests/test_levels.py
@@ -206,6 +206,7 @@ def test_imminent_raises_its_own_warning_issue_and_steps_down_again(sample_index
         "domain": "fixture_tracker",
         "release": "2027.5",
         "days": "24",
+        "day_word": "days",
         "due": "May 2027, about 24 days away",
     }
     # Nothing left over, so no summary issue.
@@ -254,6 +255,8 @@ def test_the_summary_only_counts_what_it_still_lists(sample_index):
     # The schedule pairs each release with what breaks in it, which is the
     # whole point of issue #3.
     assert placeholders["schedule"] == (
-        "2027.5 - May 2027, about 9 months away: fixture_tracker"
+        "- **May 2027, about 9 months away** (2027.5): `fixture_tracker`"
     )
+    assert placeholders["noun"] == "integration"
+    assert placeholders["verb"] == "uses"
     assert ir.created[(DOMAIN, ISSUE_ID)]["severity"] == ir.IssueSeverity.WARNING

--- a/tests/test_levels.py
+++ b/tests/test_levels.py
@@ -89,7 +89,9 @@ def test_the_estimate_matches_every_real_2026_release(release, actual):
     ],
 )
 def test_findings_are_levelled_by_urgency(sample_index, today, running, expected):
-    report = _report(sample_index, current_version=running, today=today)
+    report = _report(
+        sample_index, current_version=running, today=today, alert_window_days=30
+    )
     assert report["details"][0]["when"] == expected
 
 
@@ -204,6 +206,7 @@ def test_imminent_raises_its_own_warning_issue_and_steps_down_again(sample_index
         "domain": "fixture_tracker",
         "release": "2027.5",
         "days": "24",
+        "due": "May 2027, about 24 days away",
     }
     # Nothing left over, so no summary issue.
     assert (DOMAIN, ISSUE_ID) not in ir.created
@@ -246,5 +249,11 @@ def test_the_summary_only_counts_what_it_still_lists(sample_index):
     _sync(report)
     placeholders = ir.created[(DOMAIN, ISSUE_ID)]["translation_placeholders"]
     assert placeholders["count"] == "1"
-    assert placeholders["integrations"] == "fixture_tracker"
+    assert placeholders["earliest"] == "2027.5"
+    assert placeholders["earliest_due"] == "May 2027, about 9 months away"
+    # The schedule pairs each release with what breaks in it, which is the
+    # whole point of issue #3.
+    assert placeholders["schedule"] == (
+        "2027.5 - May 2027, about 9 months away: fixture_tracker"
+    )
     assert ir.created[(DOMAIN, ISSUE_ID)]["severity"] == ir.IssueSeverity.WARNING

--- a/tests/test_local_scan.py
+++ b/tests/test_local_scan.py
@@ -100,7 +100,7 @@ def test_true_positive_not_in_index_gets_a_local_finding(
     sensor = BreakageRadarSensor(FakeCoordinator(report))
 
     assert sensor.native_value == 1
-    assert report["by_release"] == {"2027.5": ["fixture_tracker"]}
+    assert [g["release"] for g in report["schedule"]] == ["2027.5"]
     assert report["details"] == [
         {
             "domain": "fixture_tracker",
@@ -384,7 +384,7 @@ def test_sensor_exposes_the_scan_counters(
     assert attributes["files_scanned"] == 1
     assert attributes["unparsed_files"] == 0
     assert attributes["skipped_files"] == 0
-    assert attributes["not_in_index_reasons"] == {}
+    assert attributes["not_analysed"] == []
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_local_scan.py
+++ b/tests/test_local_scan.py
@@ -112,6 +112,7 @@ def test_true_positive_not_in_index_gets_a_local_finding(
             "source": "local",
             "when": "upcoming",
             "days_until": None,
+            "due": "May 2027",
             "repository": "",
             "scanned_version": "0.1.0",
             "installed_version": "0.1.0",

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -286,3 +286,127 @@ def test_the_window_is_reported_so_the_card_can_explain_itself(many_releases):
         alert_window_days=180,
     )
     assert report["alert_window_days"] == 180
+
+
+# --------------------------------------------------------------------------- #
+# links: the notification has to lead somewhere useful
+# --------------------------------------------------------------------------- #
+
+
+def test_alert_levels_carry_the_links_needed_to_act(sample_index):
+    """A notification about someone else's code is only useful if it points
+    at that repository."""
+    report = build_report(
+        sample_index,
+        {"fixture_tracker": "0.1.0"},
+        current_version="2027.4",
+        today=date(2027, 4, 11),
+    )
+    link = report["links"]["fixture_tracker"]
+    assert link["repository"] == "example/fixture-tracker"
+    assert link["repo_url"] == "https://github.com/example/fixture-tracker"
+    assert link["learn_more"] == sample_index["rules"][0]["source"]
+
+
+def test_links_are_only_collected_for_things_worth_alerting_on(sample_index):
+    """A year-out finding is summarised, so it needs no per-integration links."""
+    report = build_report(
+        sample_index,
+        {"fixture_tracker": "0.1.0"},
+        current_version="2026.9",
+        today=date(2026, 8, 12),
+    )
+    assert report["links"] == {}
+
+
+def test_describe_links_points_at_releases_and_issues():
+    from custom_components.breakage_radar.repairs import describe_links
+
+    text = describe_links(
+        {
+            "repository": "example/thing",
+            "repo_url": "https://github.com/example/thing",
+            "learn_more": "https://developers.home-assistant.io/blog/whatever",
+        }
+    )
+    assert "[example/thing](https://github.com/example/thing/releases)" in text
+    assert "[open an issue](https://github.com/example/thing/issues)" in text
+    assert "https://developers.home-assistant.io/blog/whatever" in text
+
+
+def test_describe_links_degrades_when_the_repository_is_unknown():
+    """A locally scanned fork is not in the index, so there is no repo URL."""
+    from custom_components.breakage_radar.repairs import describe_links
+
+    text = describe_links({"repository": "", "repo_url": "", "learn_more": ""})
+    assert "integration's own repository" in text
+    assert "](" not in text
+
+
+def test_the_sensor_stays_inside_the_recorder_attribute_limit(sample_index):
+    """Home Assistant drops state attributes over 16 KB. A system with many
+    findings used to produce 19 KB, so the recorder stored nothing."""
+    import json as _json
+
+    from custom_components.breakage_radar.sensor import BreakageRadarSensor
+
+    template = sample_index["integrations"][0]
+    finding = template["findings"][0]
+    domains = [f"integration_number_{n:03d}" for n in range(60)]
+    sample_index["integrations"] = [
+        {
+            **template,
+            "domain": domain,
+            "domains": [domain],
+            "full_name": f"some-long-owner-name/{domain}-for-home-assistant",
+            "findings": [
+                {
+                    **finding,
+                    "breaks_in": "2027.5",
+                    "file": f"custom_components/{domain}/a/deeply/nested/module.py",
+                    "line": n,
+                }
+                for n in range(1, 6)
+            ],
+        }
+        for domain in domains
+    ]
+    report = build_report(
+        sample_index,
+        {d: "1.0.0" for d in domains},
+        current_version="2026.9",
+        today=date(2026, 8, 12),
+    )
+
+    class _Coordinator:
+        data = report
+        last_update_success = True
+        last_error = None
+        index_url = "https://booyaka101.github.io/hass-breakage-radar/index.json"
+
+    size = len(_json.dumps(BreakageRadarSensor(_Coordinator()).extra_state_attributes))
+    assert report["total_findings"] == 300
+    assert size < 16384, f"{size} bytes would be dropped by the recorder"
+
+
+def test_a_bare_source_reference_is_not_rendered_as_a_link():
+    """Core-derived rules cite a file and line, not a URL."""
+    from custom_components.breakage_radar.repairs import describe_links
+
+    text = describe_links(
+        {"repository": "", "repo_url": "", "learn_more": "homeassistant/helpers/service.py:418"}
+    )
+    assert "`homeassistant/helpers/service.py:418`" in text
+    assert "](homeassistant" not in text
+
+
+def test_source_url_is_preferred_over_a_bare_source(sample_index):
+    sample_index["rules"][0]["source_url"] = "https://github.com/home-assistant/core/blob/dev/x.py#L1"
+    sample_index["rules"][0]["source"] = "homeassistant/x.py:1"
+    report = build_report(
+        sample_index,
+        {"fixture_tracker": "0.1.0"},
+        current_version="2027.4",
+        today=date(2027, 4, 11),
+    )
+    assert report["links"]["fixture_tracker"]["learn_more"].startswith("https://")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,283 @@
+"""The dated schedule and the configurable alert window (issue #3).
+
+The complaint was "I'd like to see when an integration will break. Not just
+that 13 will break within the next year or so." So the report has to pair each
+release with what breaks in it, in words a person can act on.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+
+from custom_components.breakage_radar.const import (
+    DOMAIN,
+    ISSUE_ID,
+    MAX_ALERT_CARDS,
+)
+from custom_components.breakage_radar.repairs import (
+    MAX_SCHEDULE_LINES,
+    format_schedule,
+)
+from custom_components.breakage_radar.report import build_report, describe_when
+
+
+@pytest.fixture
+def sample_index(fixtures_dir):
+    return json.loads(
+        (fixtures_dir / "index_sample.json").read_text(encoding="utf-8")
+    )
+
+
+@pytest.fixture
+def many_releases(sample_index):
+    """One index, several integrations, spread across five releases."""
+    template = sample_index["integrations"][0]
+    finding = template["findings"][0]
+    releases = {
+        "2026.11": ["alpha", "beta"],
+        "2027.2": ["gamma"],
+        "2027.5": ["delta", "epsilon", "zeta"],
+        "2027.8": ["eta"],
+        "2028.1": ["theta"],
+    }
+    integrations = []
+    for release, domains in releases.items():
+        for domain in domains:
+            integrations.append(
+                {
+                    **template,
+                    "domain": domain,
+                    "domains": [domain],
+                    "full_name": f"example/{domain}",
+                    "findings": [{**finding, "breaks_in": release}],
+                }
+            )
+    sample_index["integrations"] = integrations
+    return sample_index, {d: "1.0" for ds in releases.values() for d in ds}
+
+
+@pytest.mark.parametrize(
+    "release,days,expected",
+    [
+        ("2027.5", None, "May 2027"),
+        ("2027.5", -3, "May 2027, already released"),
+        ("2027.5", 0, "May 2027, today"),
+        ("2027.5", 1, "May 2027, tomorrow"),
+        ("2027.5", 21, "May 2027, about 21 days away"),
+        ("2027.5", 44, "May 2027, about 44 days away"),
+        ("2027.5", 60, "May 2027, about 2 months away"),
+        ("2027.5", 267, "May 2027, about 9 months away"),
+        ("2027.5", 400, "May 2027, about a year away"),
+        ("2027.5", 700, "May 2027, about 1.9 years away"),
+        ("nonsense", 30, "nonsense, about 30 days away"),
+    ],
+)
+def test_describe_when_reads_like_a_person_wrote_it(release, days, expected):
+    assert describe_when(release, days) == expected
+
+
+def test_schedule_pairs_every_release_with_what_breaks_in_it(many_releases):
+    index, installed = many_releases
+    report = build_report(
+        index, installed, current_version="2026.9", today=date(2026, 8, 12)
+    )
+
+    schedule = report["schedule"]
+    assert [group["release"] for group in schedule] == [
+        "2026.11",
+        "2027.2",
+        "2027.5",
+        "2027.8",
+        "2028.1",
+    ]
+    assert schedule[0]["domains"] == ["alpha", "beta"]
+    assert schedule[0]["count"] == 2
+    assert schedule[2]["domains"] == ["delta", "epsilon", "zeta"]
+    assert schedule[0]["due"] == "November 2026, about 3 months away"
+    # 84 days out, so outside the default 30 day window.
+    assert schedule[0]["when"] == "upcoming"
+
+
+def test_schedule_sorts_by_release_not_alphabetically(sample_index):
+    """2027.10 comes after 2027.9, which a string sort gets wrong."""
+    template = sample_index["integrations"][0]
+    finding = template["findings"][0]
+    sample_index["integrations"] = [
+        {
+            **template,
+            "domain": domain,
+            "domains": [domain],
+            "findings": [{**finding, "breaks_in": release}],
+        }
+        for domain, release in (("late", "2027.10"), ("early", "2027.9"))
+    ]
+    report = build_report(
+        sample_index,
+        {"late": "1.0", "early": "1.0"},
+        current_version="2026.9",
+        today=date(2026, 8, 12),
+    )
+    assert [g["release"] for g in report["schedule"]] == ["2027.9", "2027.10"]
+
+
+def test_a_release_that_is_already_out_is_marked_broken(many_releases):
+    index, installed = many_releases
+    report = build_report(
+        index, installed, current_version="2027.3", today=date(2027, 3, 3)
+    )
+    by_release = {g["release"]: g for g in report["schedule"]}
+    assert by_release["2026.11"]["when"] == "broken_now"
+    assert by_release["2027.2"]["when"] == "broken_now"
+    assert by_release["2027.5"]["when"] == "upcoming"   # 63 days, outside 30
+    assert by_release["2028.1"]["when"] == "upcoming"
+
+
+# --------------------------------------------------------------------------- #
+# how it renders in the repairs card
+# --------------------------------------------------------------------------- #
+
+
+def test_format_schedule_is_one_readable_line_per_release(many_releases):
+    index, installed = many_releases
+    report = build_report(
+        index, installed, current_version="2026.9", today=date(2026, 8, 12)
+    )
+    text = format_schedule(report["schedule"])
+
+    assert text.splitlines()[0] == (
+        "2026.11 - November 2026, about 3 months away: alpha, beta"
+    )
+    assert "2027.5 - May 2027, about 9 months away: delta, epsilon, zeta" in text
+    assert len(text.splitlines()) == 5
+
+
+def test_format_schedule_can_show_only_the_summarised_domains(many_releases):
+    index, installed = many_releases
+    report = build_report(
+        index, installed, current_version="2026.9", today=date(2026, 8, 12)
+    )
+    text = format_schedule(report["schedule"], only={"gamma", "eta"})
+    assert text.splitlines() == [
+        "2027.2 - February 2027, about 6 months away: gamma",
+        "2027.8 - August 2027, about a year away: eta",
+    ]
+
+
+def test_format_schedule_caps_long_lists(sample_index):
+    template = sample_index["integrations"][0]
+    finding = template["findings"][0]
+    sample_index["integrations"] = [
+        {
+            **template,
+            "domain": f"domain_{n:02d}",
+            "domains": [f"domain_{n:02d}"],
+            "findings": [{**finding, "breaks_in": f"2027.{n}"}],
+        }
+        for n in range(1, 13)
+    ]
+    installed = {f"domain_{n:02d}": "1.0" for n in range(1, 13)}
+    report = build_report(
+        sample_index, installed, current_version="2026.9", today=date(2026, 8, 12)
+    )
+    lines = format_schedule(report["schedule"]).splitlines()
+    assert len(lines) == MAX_SCHEDULE_LINES + 1
+    assert lines[-1].startswith("...and 4 more")
+
+
+def test_the_summary_card_shows_the_schedule(many_releases):
+    from homeassistant.helpers import issue_registry as ir
+
+    from custom_components.breakage_radar.repairs import async_sync_issue
+
+    if not hasattr(ir, "created"):
+        pytest.skip("real Home Assistant installed; covered by HA's own harness")
+
+    ir.created.clear()
+    index, installed = many_releases
+    # A 30 day window keeps all five releases in the summary card.
+    report = build_report(
+        index,
+        installed,
+        current_version="2026.9",
+        today=date(2026, 8, 12),
+        alert_window_days=30,
+    )
+    async_sync_issue(None, report)
+
+    placeholders = ir.created[(DOMAIN, ISSUE_ID)]["translation_placeholders"]
+    assert "2026.11 - November 2026, about 3 months away: alpha, beta" in (
+        placeholders["schedule"]
+    )
+    assert placeholders["earliest_due"] == "November 2026, about 3 months away"
+    assert placeholders["window"] == "30"
+    assert placeholders["count"] == "8"
+
+
+# --------------------------------------------------------------------------- #
+# the configurable window
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "window,expected_alerts",
+    [(30, 0), (90, 1), (180, 2), (365, 4)],
+)
+def test_the_window_decides_how_much_is_alerted_on(
+    many_releases, window, expected_alerts
+):
+    """A wider window promotes more releases out of the summary."""
+    index, installed = many_releases
+    report = build_report(
+        index,
+        installed,
+        current_version="2026.9",
+        today=date(2026, 8, 12),
+        alert_window_days=window,
+    )
+    alerted = {g["release"] for g in report["schedule"] if g["when"] == "imminent"}
+    assert len(alerted) == expected_alerts
+
+
+def test_only_the_nearest_deadlines_get_their_own_notification(sample_index):
+    """A wide window on a busy system must not raise a card per integration.
+
+    Caught by previewing the cards against the live index: a 90 day window
+    turned 13 affected integrations into 13 separate notifications.
+    """
+    template = sample_index["integrations"][0]
+    finding = template["findings"][0]
+    domains = [f"domain_{n:02d}" for n in range(12)]
+    sample_index["integrations"] = [
+        {
+            **template,
+            "domain": domain,
+            "domains": [domain],
+            "findings": [{**finding, "breaks_in": "2026.11"}],
+        }
+        for domain in domains
+    ]
+    report = build_report(
+        sample_index,
+        {d: "1.0" for d in domains},
+        current_version="2026.9",
+        today=date(2026, 8, 12),
+        alert_window_days=365,
+    )
+
+    assert len(report["imminent"]) == MAX_ALERT_CARDS
+    # Nothing is lost: the rest are summarised, and the schedule still lists
+    # every one of them with its date.
+    assert len(report["summarised_domains"]) == len(domains) - MAX_ALERT_CARDS
+    assert report["schedule"][0]["count"] == len(domains)
+
+
+def test_the_window_is_reported_so_the_card_can_explain_itself(many_releases):
+    index, installed = many_releases
+    report = build_report(
+        index, installed, current_version="2026.9", today=date(2026, 8, 12),
+        alert_window_days=180,
+    )
+    assert report["alert_window_days"] == 180

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -329,8 +329,9 @@ def test_describe_links_points_at_releases_and_issues():
             "learn_more": "https://developers.home-assistant.io/blog/whatever",
         }
     )
-    assert "[example/thing](https://github.com/example/thing/releases)" in text
-    assert "[open an issue](https://github.com/example/thing/issues)" in text
+    assert "[example/thing releases](https://github.com/example/thing/releases)" in text
+    # Points at existing reports, never at a blank issue form.
+    assert "/issues/new" not in text
     assert "https://developers.home-assistant.io/blog/whatever" in text
 
 
@@ -341,6 +342,37 @@ def test_describe_links_degrades_when_the_repository_is_unknown():
     text = describe_links({"repository": "", "repo_url": "", "learn_more": ""})
     assert "integration's own repository" in text
     assert "](" not in text
+
+
+def test_describe_links_searches_for_an_existing_report(sample_index):
+    """Thousands of users filing the same issue would make this tool a
+    nuisance to maintainers, so it links the search, not a blank form."""
+    from custom_components.breakage_radar.repairs import describe_links
+
+    text = describe_links(
+        {
+            "repository": "example/thing",
+            "repo_url": "https://github.com/example/thing",
+            "symbol": "async_extract_config_entry_ids",
+            "learn_more": "",
+        }
+    )
+    assert (
+        "https://github.com/example/thing/issues?q=is%3Aissue+"
+        "async_extract_config_entry_ids" in text
+    )
+    assert "reaction" in text
+    assert "/issues/new" not in text
+
+
+def test_the_symbol_travels_with_the_link(sample_index):
+    report = build_report(
+        sample_index,
+        {"fixture_tracker": "0.1.0"},
+        current_version="2027.4",
+        today=date(2027, 4, 11),
+    )
+    assert report["links"]["fixture_tracker"]["symbol"] == "setup_scanner"
 
 
 def test_the_sensor_stays_inside_the_recorder_attribute_limit(sample_index):

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -279,15 +279,6 @@ def test_only_the_nearest_deadlines_get_their_own_notification(sample_index):
     assert report["schedule"][0]["count"] == len(domains)
 
 
-def test_the_window_is_reported_so_the_card_can_explain_itself(many_releases):
-    index, installed = many_releases
-    report = build_report(
-        index, installed, current_version="2026.9", today=date(2026, 8, 12),
-        alert_window_days=180,
-    )
-    assert report["alert_window_days"] == 180
-
-
 # --------------------------------------------------------------------------- #
 # links: the notification has to lead somewhere useful
 # --------------------------------------------------------------------------- #
@@ -306,17 +297,6 @@ def test_alert_levels_carry_the_links_needed_to_act(sample_index):
     assert link["repository"] == "example/fixture-tracker"
     assert link["repo_url"] == "https://github.com/example/fixture-tracker"
     assert link["learn_more"] == sample_index["rules"][0]["source"]
-
-
-def test_links_are_only_collected_for_things_worth_alerting_on(sample_index):
-    """A year-out finding is summarised, so it needs no per-integration links."""
-    report = build_report(
-        sample_index,
-        {"fixture_tracker": "0.1.0"},
-        current_version="2026.9",
-        today=date(2026, 8, 12),
-    )
-    assert report["links"] == {}
 
 
 def test_describe_links_points_at_releases_and_issues():

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -148,9 +148,12 @@ def test_format_schedule_is_one_readable_line_per_release(many_releases):
     text = format_schedule(report["schedule"])
 
     assert text.splitlines()[0] == (
-        "2026.11 - November 2026, about 3 months away: alpha, beta"
+        "- **November 2026, about 3 months away** (2026.11): `alpha`, `beta`"
     )
-    assert "2027.5 - May 2027, about 9 months away: delta, epsilon, zeta" in text
+    assert (
+        "- **May 2027, about 9 months away** (2027.5): "
+        "`delta`, `epsilon`, `zeta`" in text
+    )
     assert len(text.splitlines()) == 5
 
 
@@ -161,8 +164,8 @@ def test_format_schedule_can_show_only_the_summarised_domains(many_releases):
     )
     text = format_schedule(report["schedule"], only={"gamma", "eta"})
     assert text.splitlines() == [
-        "2027.2 - February 2027, about 6 months away: gamma",
-        "2027.8 - August 2027, about a year away: eta",
+        "- **February 2027, about 6 months away** (2027.2): `gamma`",
+        "- **August 2027, about a year away** (2027.8): `eta`",
     ]
 
 
@@ -184,7 +187,7 @@ def test_format_schedule_caps_long_lists(sample_index):
     )
     lines = format_schedule(report["schedule"]).splitlines()
     assert len(lines) == MAX_SCHEDULE_LINES + 1
-    assert lines[-1].startswith("...and 4 more")
+    assert lines[-1].startswith("- ...and 4 more")
 
 
 def test_the_summary_card_shows_the_schedule(many_releases):
@@ -208,9 +211,11 @@ def test_the_summary_card_shows_the_schedule(many_releases):
     async_sync_issue(None, report)
 
     placeholders = ir.created[(DOMAIN, ISSUE_ID)]["translation_placeholders"]
-    assert "2026.11 - November 2026, about 3 months away: alpha, beta" in (
+    assert "**November 2026, about 3 months away** (2026.11)" in (
         placeholders["schedule"]
     )
+    assert placeholders["noun"] == "integrations"
+    assert placeholders["verb"] == "use"
     assert placeholders["earliest_due"] == "November 2026, about 3 months away"
     assert placeholders["window"] == "30"
     assert placeholders["count"] == "8"


### PR DESCRIPTION
Closes #3.

## The problem

The summary notification listed affected integrations in one line and their release deadlines in another, so with 13 affected you could see that 13 break and that some break in 2027.5, but not which. That is what the issue asks for.

## What it looks like now

Rendered from live index data, a system with 13 affected integrations:

```
13 custom integration(s) will break in a future Home Assistant release

These installed custom integrations use Home Assistant APIs that are scheduled
for removal. Nothing breaks today, and the first deadline is October 2026,
about 2 months away.

What breaks, and when:

2026.10 - October 2026, about 2 months away: argoclima, hisense_vidaa, miele and 1 more
2026.11 - November 2026, about 3 months away: bosch, octopus_energy, spook
2027.8  - August 2027, about a year away: yandex_station
```

Dates are phrased the way someone would say them rather than as day counts. The same schedule is on the sensor as a `schedule` attribute and each finding gained a readable `due` field, so a dashboard card is easy to build from it. Releases now sort numerically, so 2027.10 comes after 2027.9.

## The window is configurable

Settings > Devices & Services > Breakage Radar > Configure. 30, 60 or 90 days, 6 months or a year, applied without a restart. Default stays 30 days.

The issue asked for 3 months, and that is available, but previewing the cards against the live index caught why it should not be the default: a 90 day window turned all 13 affected integrations into 13 separate notifications, which is the spam the levels were meant to avoid. At most five notifications are raised now whatever the window, and the rest stay in the summary which lists every date anyway.

## Cleanup in the files this touches

- All three notifications and the options screen rewritten in plain language.
- Rationale comments trimmed from the modules changed here, plus `scanner.py` and `discovery.py`, which were the densest. Comment-only, no behaviour change.
- First tests for `config_flow.py`. Nothing imported it before, so a broken import would only have surfaced when a user tried to add the integration, which is how #1 reached someone's system. Doing this found that `voluptuous` was not stubbed for tests at all.
- HACS minimum raised to 2024.11, the release where `OptionsFlow` gained its `config_entry` property. Setting it manually has been deprecated since then.

188 passed, 3 skipped on 3.11 and 3.12, up from 159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)