### PR TITLE
Do not flag an awaited call as DeviceRegistry.async_get_device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
+## 1.3.1 — 2026-08-12
+
+* **An awaited call is no longer reported as `DeviceRegistry.async_get_device`.**
+  That rule accounts for 328 of the affected integrations, so it was checked
+  against real source: 44 of 45 hand-verified findings were genuine. The one
+  that was not awaited its own API client's method of the same name. Core
+  defines the registry method as a plain `def` taking `identifiers` or
+  `connections`, so an awaited call cannot be it. Matchers gained an opt-in
+  `not_awaited` constraint and that rule now sets it.
+
+  Re-scanned against live source under Python 3.14: all 36 sampled repositories
+  the rule hits are unchanged, and the false positive drops to zero. Roughly 2%
+  of that rule's repositories, about seven maintainers, stop being told about a
+  problem they do not have.
+
+  Your local scan picks this up as soon as you update. The published index
+  corrects itself over the following days as the daily crawl works back through
+  the catalogue, which `ENGINE_VERSION` 4 forces.
+
 ## 1.3.0 — 2026-08-12
 
 ### You can now see what breaks when (#3)

--- a/custom_components/breakage_radar/manifest.json
+++ b/custom_components/breakage_radar/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/Booyaka101/hass-breakage-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/custom_components/breakage_radar/rules_engine.py
+++ b/custom_components/breakage_radar/rules_engine.py
@@ -18,10 +18,12 @@ Eight matcher types cover every deprecation Breakage Radar currently ships:
                        where the *argument* is deprecated, not the function
 
 Every matcher may additionally be constrained with ``files`` (a list of exact
-basenames, e.g. ``["device_tracker.py"]``) and ``attr`` matchers with
-``in_class_base`` (the enclosing class must derive from one of these names).
-Those constraints are what keep the false-positive rate at zero on lookalike
-code -- see ``tests/test_scanner.py``.
+basenames, e.g. ``["device_tracker.py"]``), ``attr`` matchers with
+``in_class_base`` (the enclosing class must derive from one of these names),
+and ``call`` matchers with ``not_awaited`` (skip awaited calls, for symbols
+Home Assistant defines with a plain ``def``). Those constraints are what keep
+the false-positive rate at zero on lookalike code -- see
+``tests/test_scanner.py``.
 
 Standard library only: this module is imported by the crawler and vendored
 byte-for-byte at ``custom_components/breakage_radar/rules_engine.py``, where the
@@ -53,7 +55,7 @@ MATCHER_TYPES = frozenset(
 #: Bumped whenever matching semantics change. It is folded into the crawl's
 #: rules hash, so an engine change forces a rescan instead of leaving stale
 #: findings that the current engine would no longer produce.
-ENGINE_VERSION = 3
+ENGINE_VERSION = 4
 
 VERSION_RE = re.compile(r"^\d{4}\.\d+(?:\.\d+)?$")
 
@@ -375,12 +377,27 @@ def _assign_target_name(target: ast.expr) -> str | None:
     return None
 
 
+def _awaited_calls(tree: ast.Module) -> set[int]:
+    """Calls that are directly awaited.
+
+    ``async_`` in Home Assistant means callback-safe, not coroutine, so several
+    deprecated helpers are plain ``def``. Awaiting one is proof it is somebody
+    else's method that merely shares the name.
+    """
+    return {
+        id(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Await) and isinstance(node.value, ast.Call)
+    }
+
+
 def _match_call(
     matcher: dict[str, Any], tree: ast.Module, imports: dict[str, str]
 ) -> Iterator[tuple[int, str]]:
     names = set(matcher.get("names", ()))
+    awaited = _awaited_calls(tree) if matcher.get("not_awaited") else frozenset()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
+        if isinstance(node, ast.Call) and id(node) not in awaited:
             name = _called_name(node)
             if name in names and _module_allowed(matcher, node, name, imports):
                 yield node.lineno, name

--- a/data/manual_rules.json
+++ b/data/manual_rules.json
@@ -168,7 +168,8 @@
         "type": "call",
         "names": ["async_get_device"],
         "modules": ["homeassistant.helpers.device_registry"],
-        "allow_unresolved_attribute": true
+        "allow_unresolved_attribute": true,
+        "not_awaited": true
       }
     },
     {

--- a/data/rules.json
+++ b/data/rules.json
@@ -2280,7 +2280,8 @@
         "modules": [
           "homeassistant.helpers.device_registry"
         ],
-        "allow_unresolved_attribute": true
+        "allow_unresolved_attribute": true,
+        "not_awaited": true
       },
       "matchable": true,
       "expired": false
@@ -2315,5 +2316,5 @@
       "expired": false
     }
   ],
-  "blog_merged_utc": "2026-08-12T03:58:29Z"
+  "blog_merged_utc": "2026-08-12T11:38:15Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-breakage-radar"
-version = "1.3.0"
+version = "1.3.1"
 description = "Find out which of your Home Assistant custom integrations stop working, and in which future release."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -233,3 +233,28 @@ def test_verify_domain_control_decorator_without_hass_is_clean(rules):
         "    return None\n"
     )
     assert match_source("custom_components/x/services.py", source, rules) == []
+
+
+def test_awaited_async_get_device_is_somebody_elses_method(rules):
+    """DeviceRegistry.async_get_device is a plain def in core, so a call that
+    is awaited cannot be it.
+
+    Measured on ThomasLomas/ha-starlinghomehub, which awaits its own API
+    client's method of the same name. That was the only false positive in 45
+    hand-checked hits of this rule.
+    """
+    source = (
+        "from homeassistant.helpers import device_registry as dr\n"
+        "\n"
+        "\n"
+        "async def refresh(self, hass, device):\n"
+        "    theirs = await self.client.async_get_device(device_id=device['id'])\n"
+        "    registry = dr.async_get(hass)\n"
+        "    ours = registry.async_get_device(identifiers={('x', 'y')})\n"
+        "    return theirs, ours\n"
+    )
+    hits = [
+        f for f in match_source("custom_components/x/coordinator.py", source, rules)
+        if f.rule_id == "device-registry-async-get-device"
+    ]
+    assert [f.line for f in hits] == [7]

--- a/tools/rules_engine.py
+++ b/tools/rules_engine.py
@@ -18,10 +18,12 @@ Eight matcher types cover every deprecation Breakage Radar currently ships:
                        where the *argument* is deprecated, not the function
 
 Every matcher may additionally be constrained with ``files`` (a list of exact
-basenames, e.g. ``["device_tracker.py"]``) and ``attr`` matchers with
-``in_class_base`` (the enclosing class must derive from one of these names).
-Those constraints are what keep the false-positive rate at zero on lookalike
-code -- see ``tests/test_scanner.py``.
+basenames, e.g. ``["device_tracker.py"]``), ``attr`` matchers with
+``in_class_base`` (the enclosing class must derive from one of these names),
+and ``call`` matchers with ``not_awaited`` (skip awaited calls, for symbols
+Home Assistant defines with a plain ``def``). Those constraints are what keep
+the false-positive rate at zero on lookalike code -- see
+``tests/test_scanner.py``.
 
 Standard library only: this module is imported by the crawler and vendored
 byte-for-byte at ``custom_components/breakage_radar/rules_engine.py``, where the
@@ -53,7 +55,7 @@ MATCHER_TYPES = frozenset(
 #: Bumped whenever matching semantics change. It is folded into the crawl's
 #: rules hash, so an engine change forces a rescan instead of leaving stale
 #: findings that the current engine would no longer produce.
-ENGINE_VERSION = 3
+ENGINE_VERSION = 4
 
 VERSION_RE = re.compile(r"^\d{4}\.\d+(?:\.\d+)?$")
 
@@ -375,12 +377,27 @@ def _assign_target_name(target: ast.expr) -> str | None:
     return None
 
 
+def _awaited_calls(tree: ast.Module) -> set[int]:
+    """Calls that are directly awaited.
+
+    ``async_`` in Home Assistant means callback-safe, not coroutine, so several
+    deprecated helpers are plain ``def``. Awaiting one is proof it is somebody
+    else's method that merely shares the name.
+    """
+    return {
+        id(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Await) and isinstance(node.value, ast.Call)
+    }
+
+
 def _match_call(
     matcher: dict[str, Any], tree: ast.Module, imports: dict[str, str]
 ) -> Iterator[tuple[int, str]]:
     names = set(matcher.get("names", ()))
+    awaited = _awaited_calls(tree) if matcher.get("not_awaited") else frozenset()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
+        if isinstance(node, ast.Call) and id(node) not in awaited:
             name = _called_name(node)
             if name in names and _module_allowed(matcher, node, name, imports):
                 yield node.lineno, name


### PR DESCRIPTION
## Why

`device-registry-async-get-device` carries 328 of the 593 affected integrations and nearly all of the 2027.8 cliff, at medium confidence. Nobody had checked whether it was right.

I hand-verified 45 of its findings against real source, in two samples taken from different slices of the catalogue. **44 were genuine** — the receiver was bound by `dr.async_get(hass)`, annotated `DeviceRegistry`, or read from `hass.data["device_registry"]`. The 11.3% hit rate is legitimate: almost every integration that creates devices looks one up.

## The one false positive

`ThomasLomas/ha-starlinghomehub`:

```python
full_device = await self.client.async_get_device(device_id=device["id"])
```

That is their own API client. Core defines the real method as a plain `def` taking `identifiers`/`connections` (checked in `homeassistant/helpers/device_registry.py` on `dev`), so an awaited call cannot be it. `async_` in Home Assistant means callback-safe, not coroutine.

## The change

An opt-in `not_awaited` constraint for `call` matchers, set on that one rule. Verified under Python 3.14 against live source:

- 36 repos the rule currently hits, re-scanned with both matchers: **36 unchanged, 0 lost**
- the false positive: **1 finding before, 0 after**

## Cost

`ENGINE_VERSION` goes 3 → 4. The rule's own `match` object changed, which already invalidates `rules_hash` and forces a full re-crawl, so the bump adds nothing and keeps the version honest. Expect roughly eight days for the daily crawl to work back through the catalogue, with a mixed-engine index meanwhile. That is the mechanism working as designed.

Roughly 2% of 328 repos, about seven maintainers, stop being told they have a problem they do not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)