### PR TITLE
Tell people whether the problem is already reported upstream

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -58,6 +58,10 @@ jobs:
         run: python tools/catalog.py
 
       - name: Scan a slice of the catalogue
+        # The token is only used to ask whether a deprecation is already
+        # reported on the repositories this slice found problems in.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python tools/scan.py \
             --limit "${{ github.event.inputs.limit || '400' }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
+## 1.4.0 — 2026-08-12
+
+### Notifications know whether the problem is already reported
+
+The crawler now asks each affected repository what it already says about the
+deprecation, and publishes the answer in the index, so nobody has to search and
+nobody files a duplicate. A notification says one of:
+
+* **already reported and open** — links the issue and asks you to add a
+  reaction there instead of opening another one
+* **reported and closed** — links it and says a fix may already have shipped,
+  which usually means updating is enough
+* **archived repository** — says no fix is coming and to plan a replacement,
+  rather than sending you to a dead tracker
+* **issues disabled** — says there is nowhere to report it
+* **nothing found** — links a search for the symbol, as before
+
+Only issues that look like they are about the deprecation count. Searching a
+symbol also matches tracebacks pasted into unrelated bug reports: one real
+repository returned "Bug: Everything is unavailable" for a symbol search, and
+linking someone to that as "the report" would be worse than saying nothing. A
+title has to name the symbol or use removal language to qualify.
+
+The lookup runs in the crawler, not on your system. It needs a GitHub token and
+the search API allows 30 requests a minute, so doing it per user would need a
+token from each of them. It rides along with the daily slice, so coverage grows
+at the same rate as the scan itself.
+
+New optional `upstream` field on index integrations. The index is still
+schema 1 and older versions of the integration ignore it.
+
 ## 1.3.1 — 2026-08-12
 
 * **An awaited call is no longer reported as `DeviceRegistry.async_get_device`.**

--- a/README.md
+++ b/README.md
@@ -489,6 +489,12 @@ list core dispatches on in `homeassistant/components/device_tracker/legacy.py`:
 `integrations` lists only repositories **with** findings. `clean_domains` lists the ones
 scanned and found clean, so a consumer can tell "no problems" from "not looked at yet".
 
+An affected integration may also carry `upstream`, recording what its own
+repository says: whether it is archived, whether it accepts issues, and the most
+relevant existing report if there is one. That is what lets a notification say
+"already reported, add a reaction there" instead of sending everybody to open
+the same issue. It is optional, so an older index simply lacks it.
+
 Every `matchable: true` rule ships its matcher as the nested `match` object — that is
 what lets the integration run the same rules over locally installed code without the
 index changing shape for it.

--- a/custom_components/breakage_radar/manifest.json
+++ b/custom_components/breakage_radar/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/Booyaka101/hass-breakage-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.3.1"
+  "version": "1.4.0"
 }

--- a/custom_components/breakage_radar/repairs.py
+++ b/custom_components/breakage_radar/repairs.py
@@ -73,14 +73,42 @@ def describe_links(link: dict | None) -> str:
     repository = link.get("repository") or "the integration's repository"
     symbol = link.get("symbol") or ""
     learn_more = link.get("learn_more") or ""
+    report = link.get("report") or {}
 
     parts: list[str] = []
-    if repo_url:
+    if not repo_url:
+        parts.append(
+            "Check the integration's own repository for a newer release, and "
+            "its issue tracker before reporting anything."
+        )
+    elif link.get("archived"):
+        parts.append(
+            f"[{repository}]({repo_url}) is archived, so no fix is coming. "
+            "Plan to replace this integration."
+        )
+    else:
         parts.append(
             f"First check [{repository} releases]({repo_url}/releases) for a "
             "version that fixes it."
         )
-        if symbol:
+        if report and report.get("state") == "open":
+            parts.append(
+                f"It is already reported: [#{report['number']} "
+                f"{report['title']}]({report['url']}). Add a reaction there "
+                "rather than opening another one."
+            )
+        elif report:
+            parts.append(
+                f"It was reported and closed: [#{report['number']} "
+                f"{report['title']}]({report['url']}), so a fix may already "
+                "have shipped."
+            )
+        elif link.get("issues_enabled") is False:
+            parts.append(
+                "That repository does not accept issues, so there is nowhere "
+                "to report it."
+            )
+        elif symbol:
             query = quote_plus(f"is:issue {symbol}")
             parts.append(
                 f"If there isn't one, [see whether it is already "
@@ -93,11 +121,6 @@ def describe_links(link: dict | None) -> str:
                 f"If there isn't one, check [the issue tracker]({repo_url}/issues) "
                 "before reporting it, so the maintainer does not get duplicates."
             )
-    else:
-        parts.append(
-            "Check the integration's own repository for a newer release, and "
-            "its issue tracker before reporting anything."
-        )
     if learn_more.startswith("http"):
         parts.append(f"[What Home Assistant is changing]({learn_more})")
     elif learn_more:

--- a/custom_components/breakage_radar/report.py
+++ b/custom_components/breakage_radar/report.py
@@ -170,6 +170,7 @@ def build_report(
             if when in ("broken_now", "imminent"):
                 # What the notification needs to point somewhere useful.
                 rule = rules.get(finding.get("rule_id"), {})
+                upstream = (entry or {}).get("upstream") or {}
                 links.setdefault(
                     domain,
                     {
@@ -183,6 +184,11 @@ def build_report(
                         "learn_more": (
                             rule.get("source_url") or rule.get("source") or ""
                         ),
+                        # What the crawler already found upstream, so nobody
+                        # files a report that exists.
+                        "archived": bool(upstream.get("archived")),
+                        "issues_enabled": upstream.get("issues_enabled"),
+                        "report": upstream.get("report") or {},
                     },
                 )
             rule = rules.get(finding.get("rule_id"), {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-breakage-radar"
-version = "1.3.1"
+version = "1.4.0"
 description = "Find out which of your Home Assistant custom integrations stop working, and in which future release."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -422,3 +422,71 @@ def test_source_url_is_preferred_over_a_bare_source(sample_index):
         today=date(2027, 4, 11),
     )
     assert report["links"]["fixture_tracker"]["learn_more"].startswith("https://")
+
+
+# --------------------------------------------------------------------------- #
+# upstream: what the crawler already found out about the repository
+# --------------------------------------------------------------------------- #
+
+
+def _links(sample_index, upstream):
+    sample_index["integrations"][0]["upstream"] = upstream
+    report = build_report(
+        sample_index,
+        {"fixture_tracker": "0.1.0"},
+        current_version="2027.4",
+        today=date(2027, 4, 11),
+    )
+    return report["links"]["fixture_tracker"]
+
+
+def test_an_open_report_is_offered_for_a_reaction(sample_index):
+    from custom_components.breakage_radar.repairs import describe_links
+
+    text = describe_links(_links(sample_index, {
+        "archived": False, "issues_enabled": True,
+        "report": {"number": 41, "state": "open", "url": "https://github.com/example/x/issues/41",
+                   "title": "The deprecated argument hass was passed to verify_domain_control"},
+    }))
+    assert "already reported" in text
+    assert "[#41 The deprecated argument" in text
+    assert "Add a reaction" in text
+    assert "issues?q=" not in text          # no need to send them searching
+
+
+def test_a_closed_report_points_at_a_probable_fix(sample_index):
+    from custom_components.breakage_radar.repairs import describe_links
+
+    text = describe_links(_links(sample_index, {
+        "archived": False, "issues_enabled": True,
+        "report": {"number": 320, "state": "closed", "url": "https://github.com/example/x/issues/320",
+                   "title": "Remove deprecated argument (2026.10)"},
+    }))
+    assert "reported and closed" in text
+    assert "a fix may already have shipped" in text
+
+
+def test_an_archived_repository_says_so_instead_of_sending_people_there(sample_index):
+    from custom_components.breakage_radar.repairs import describe_links
+
+    text = describe_links(_links(sample_index, {"archived": True, "issues_enabled": False}))
+    assert "archived" in text
+    assert "replace this integration" in text
+    assert "/releases" not in text
+    assert "/issues" not in text
+
+
+def test_a_repository_with_issues_disabled_does_not_send_people_to_report(sample_index):
+    from custom_components.breakage_radar.repairs import describe_links
+
+    text = describe_links(_links(sample_index, {"archived": False, "issues_enabled": False}))
+    assert "does not accept issues" in text
+    assert "issues?q=" not in text
+
+
+def test_without_upstream_facts_it_still_links_the_search(sample_index):
+    """An index built before the lookup existed, or a repo not yet visited."""
+    from custom_components.breakage_radar.repairs import describe_links
+
+    text = describe_links(_links(sample_index, {}))
+    assert "issues?q=is%3Aissue+setup_scanner" in text

--- a/tests/test_upstream.py
+++ b/tests/test_upstream.py
@@ -1,0 +1,53 @@
+"""Choosing which existing issue, if any, is worth linking someone to.
+
+Searching a deprecated symbol also matches tracebacks pasted into unrelated
+bug reports. Measured on real repositories: "Bug: Everything is unavailable"
+came back for a symbol search purely because the traceback contained it, so a
+raw search hit is not evidence on its own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.upstream import relevance, search_term
+
+
+@pytest.mark.parametrize(
+    "symbol,expected",
+    [
+        ("DeviceRegistry.async_get_device", "async_get_device"),
+        ("async_import_statistics(missing metadata)", "async_import_statistics"),
+        ("verify_domain_control", "verify_domain_control"),
+        ("", ""),
+    ],
+)
+def test_search_term_reduces_a_symbol_to_what_someone_would_paste(symbol, expected):
+    assert search_term(symbol) == expected
+
+
+@pytest.mark.parametrize(
+    "title,symbol,wanted",
+    [
+        # Real titles, from repositories the crawler has scanned.
+        ("Deprecated argument hass was passed to async_extract_config_entry_ids",
+         "async_extract_config_entry_ids", True),
+        ("The deprecated argument hass was passed to verify_domain_control",
+         "verify_domain_control", True),
+        ("Scheduled API removals: statistics metadata (2026.11)",
+         "async_import_statistics", True),
+        ("Specify mean_type when calling async_import_statistics",
+         "async_import_statistics", True),
+        # The false match that made this gate necessary.
+        ("Bug: Everything is unavailable", "async_extract_entity_ids", False),
+        ("Add support for the new sensor", "async_get_device", False),
+    ],
+)
+def test_only_titles_that_look_like_the_deprecation_count(title, symbol, wanted):
+    assert (relevance(title, symbol) > 0) is wanted
+
+
+def test_a_symbol_in_the_title_outranks_a_generic_deprecation_notice():
+    named = relevance("async_get_device is deprecated", "async_get_device")
+    generic = relevance("Upcoming breaking changes", "async_get_device")
+    assert named > generic > 0

--- a/tools/build_index.py
+++ b/tools/build_index.py
@@ -134,22 +134,23 @@ def build_payload(
             rule_repos[rule_id] += 1
 
         findings.sort(key=lambda f: (parse_version(f["breaks_in"]), f["file"], f["line"]))
-        integrations.append(
-            {
-                "full_name": full_name,
-                "domain": domain,
-                "domains": record.get("domains", [domain] if domain else []),
-                "version": record.get("version", ""),
-                "ref": record.get("ref", ""),
-                "stargazers_count": catalog_entry.get(
-                    "stargazers_count", record.get("stargazers_count", 0)
-                ),
-                "repo_url": f"https://github.com/{full_name}",
-                "scanned_utc": record.get("scanned_utc", ""),
-                "earliest_breaks_in": findings[0]["breaks_in"],
-                "findings": findings,
-            }
-        )
+        entry = {
+            "full_name": full_name,
+            "domain": domain,
+            "domains": record.get("domains", [domain] if domain else []),
+            "version": record.get("version", ""),
+            "ref": record.get("ref", ""),
+            "stargazers_count": catalog_entry.get(
+                "stargazers_count", record.get("stargazers_count", 0)
+            ),
+            "repo_url": f"https://github.com/{full_name}",
+            "scanned_utc": record.get("scanned_utc", ""),
+            "earliest_breaks_in": findings[0]["breaks_in"],
+            "findings": findings,
+        }
+        if record.get("upstream"):
+            entry["upstream"] = record["upstream"]
+        integrations.append(entry)
 
     integrations.sort(
         key=lambda i: (

--- a/tools/scan.py
+++ b/tools/scan.py
@@ -58,6 +58,7 @@ from tools.rules_engine import (  # noqa: E402
     match_source,
     matchable_rules,
 )
+from tools.upstream import annotate  # noqa: E402
 
 CODELOAD = "https://codeload.github.com/{full_name}/tar.gz/{ref}"
 
@@ -278,6 +279,11 @@ def main(argv: list[str] | None = None) -> int:
         "--force", action="store_true", help="rescan even if nothing changed"
     )
     parser.add_argument(
+        "--no-upstream",
+        action="store_true",
+        help="skip looking up existing issues on the scanned repositories",
+    )
+    parser.add_argument(
         "--sleep",
         type=float,
         default=0.0,
@@ -416,6 +422,13 @@ def main(argv: list[str] | None = None) -> int:
             time.sleep(args.sleep)
 
     checkpoint()
+
+    if not args.no_upstream:
+        scanned_now = {n: repos[n] for n in (e["full_name"] for e in todo) if n in repos}
+        looked_up = annotate(scanned_now, {r.id: {"symbol": r.symbol} for r in active})
+        if looked_up:
+            LOGGER.info("looked up upstream issues for %d repo(s)", looked_up)
+            checkpoint()
 
     LOGGER.info(
         "slice done in %.0fs: %s | state has %d repos, findings file has %d repos%s",

--- a/tools/upstream.py
+++ b/tools/upstream.py
@@ -1,0 +1,181 @@
+"""Looks up what an integration's own repository already says about a finding.
+
+A user told "this breaks" needs to know whether it is already reported before
+doing anything. Asking every user's Home Assistant to search GitHub would need
+a token from each of them and would hit the 30 requests per minute search
+limit immediately, so the crawler does it once and publishes the answer.
+
+Only reports that look like they are about the deprecation are returned. A
+search for the symbol also matches tracebacks pasted into unrelated bug
+reports, and linking someone to "Bug: everything is unavailable" as though it
+were the report would be worse than saying nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from tools.common import LOGGER
+
+API = "https://api.github.com"
+
+#: The search API allows 30 requests a minute, authenticated or not.
+SEARCH_INTERVAL = 2.1
+
+#: Words that suggest an issue is about a scheduled removal.
+DEPRECATION_WORDS = re.compile(
+    r"deprecat|removal|removed|breaking change|\b20\d\d\.\d+\b", re.I
+)
+
+
+class SearchExhausted(RuntimeError):
+    """The search rate limit is spent; stop looking things up this run."""
+
+
+def search_term(symbol: str) -> str:
+    """The searchable part of a rule symbol.
+
+    ``DeviceRegistry.async_get_device`` and
+    ``async_import_statistics(missing metadata)`` both reduce to the bare
+    function name, which is what someone would paste into an issue.
+    """
+    return symbol.split("(")[0].strip().split(".")[-1].strip()
+
+
+def _token() -> str | None:
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+
+
+def _api(path: str, *, token: str, params: dict[str, str] | None = None) -> Any:
+    url = f"{API}{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "breakage-radar",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as err:
+        if err.code in (403, 429):
+            raise SearchExhausted(f"{path}: HTTP {err.code}") from err
+        raise
+
+
+def relevance(title: str, symbol: str) -> int:
+    """How much an issue title looks like it is about this deprecation."""
+    score = 0
+    if symbol and symbol.lower() in title.lower():
+        score += 2
+    if DEPRECATION_WORDS.search(title):
+        score += 1
+    return score
+
+
+def find_report(full_name: str, symbol: str, *, token: str) -> dict[str, Any] | None:
+    """The most relevant existing issue about ``symbol``, or None.
+
+    Open issues win over closed ones at equal relevance, because an open
+    report is the one worth adding a reaction to.
+    """
+    term = search_term(symbol)
+    if not term:
+        return None
+    payload = _api(
+        "/search/issues",
+        token=token,
+        params={"q": f'repo:{full_name} is:issue "{term}"', "per_page": "10"},
+    )
+    best = None
+    for item in payload.get("items", []):
+        score = relevance(item.get("title", ""), term)
+        if score <= 0:
+            continue                       # matched the body only; not evidence
+        rank = (score, item.get("state") == "open")
+        if best is None or rank > best[0]:
+            best = (
+                rank,
+                {
+                    "number": item.get("number"),
+                    "url": item.get("html_url", ""),
+                    "state": item.get("state", ""),
+                    "title": (item.get("title") or "")[:140],
+                    "reactions": (item.get("reactions") or {}).get("total_count", 0),
+                },
+            )
+    return best[1] if best else None
+
+
+def repo_facts(full_name: str, *, token: str) -> dict[str, Any]:
+    """Whether the repository still accepts reports at all."""
+    data = _api(f"/repos/{full_name}", token=token)
+    return {
+        "archived": bool(data.get("archived")),
+        "issues_enabled": bool(data.get("has_issues")),
+    }
+
+
+def look_up(full_name: str, symbol: str, *, token: str | None = None) -> dict[str, Any]:
+    """Repository facts plus any existing report. Never raises except when the
+    rate limit is spent, which the caller uses to stop early."""
+    token = token or _token()
+    if not token:
+        return {}
+    facts = repo_facts(full_name, token=token)
+    if facts["issues_enabled"] and not facts["archived"]:
+        report = find_report(full_name, symbol, token=token)
+        time.sleep(SEARCH_INTERVAL)
+        if report:
+            facts["report"] = report
+    return facts
+
+
+def annotate(
+    records: dict[str, Any], rules_by_id: dict[str, Any], *, limit: int = 400
+) -> int:
+    """Add upstream facts to scan records that have findings.
+
+    Returns how many were looked up. Anything that fails is skipped rather
+    than allowed to fail the crawl: this is extra context, not the product.
+    """
+    token = _token()
+    if not token:
+        LOGGER.info("no GITHUB_TOKEN; skipping upstream issue lookup")
+        return 0
+
+    done = 0
+    for full_name, record in records.items():
+        if done >= limit:
+            break
+        findings = record.get("findings") or []
+        if not findings:
+            record.pop("upstream", None)
+            continue
+        earliest = min(findings, key=lambda f: f.get("breaks_in", ""))
+        rule = rules_by_id.get(earliest.get("rule_id"), {})
+        try:
+            facts = look_up(full_name, rule.get("symbol", ""), token=token)
+        except SearchExhausted as err:
+            LOGGER.warning("upstream lookup stopped early: %s", err)
+            break
+        except Exception as err:  # noqa: BLE001 - context is optional
+            LOGGER.debug("upstream lookup failed for %s: %s", full_name, err)
+            continue
+        if facts:
+            facts["symbol"] = search_term(rule.get("symbol", ""))
+            record["upstream"] = facts
+            done += 1
+    return done


### PR DESCRIPTION
Follows the direction set when we stopped linking blank issue forms: the notification should know what the repository already says, rather than sending everyone to look.

## What a notification says now

Real output, generated against the live index with the lookup running:

> **argoclima breaks in about 56 days**
>
> First check [nyffchanium/argoclima-integration releases](https://github.com/nyffchanium/argoclima-integration/releases) for a version that fixes it.
>
> It is already reported: [#41 The deprecated argument hass was passed to verify_domain_control from argoclima](https://github.com/nyffchanium/argoclima-integration/issues/41). Add a reaction there rather than opening another one.

> **homeconnect_ws breaks in about 56 days**
>
> It was reported and closed: [#404 Deprecated argument hass was passed to async_extract_config_entry_ids. Will be removed in 2026.10](https://github.com/chris-mc1/homeconnect_local_hass/issues/404), so a fix may already have shipped.

Five outcomes: open report (react to it), closed report (a fix likely shipped), archived repository (no fix is coming, plan a replacement), issues disabled (nowhere to report), nothing found (link the search, as before).

## Why a relevance gate

A raw symbol search is not evidence. One real repository returns `"Bug: Everything is unavailable"` for `async_extract_entity_ids` because the symbol appears in a pasted traceback, and linking someone to that as "the report" would be worse than saying nothing. A title has to name the symbol or use removal language to qualify. Checked against the real cases: the three genuine reports pass, that one fails.

## Why it lives in the crawler

The GitHub search API allows **30 requests a minute**, authenticated or not. Doing this on each user's system would need a token from every one of them and would break the "no account, no API key" promise. The crawler has a token, does it once, and everyone shares the answer. It rides along with the existing daily slice, so upstream coverage grows at the same rate as the scan. `--no-upstream` skips it, and without a token it is silently skipped, so local runs are unaffected.

## Compatibility

New optional `upstream` field on index integrations. The index stays **schema 1**, so installs on older versions ignore it rather than rejecting the index. Bumping the schema would have broken every existing user.

214 tests, up from 203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)