### PR TITLE
Let the crawl push after main moves under it

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -89,4 +89,21 @@ jobs:
           SCANNED=$(python -c "import json;print(json.load(open('docs/index.json'))['coverage']['repos_scanned'])")
           AFFECTED=$(python -c "import json;print(json.load(open('docs/index.json'))['coverage']['repos_affected'])")
           git commit -m "chore(crawl): refresh index (${SCANNED} scanned, ${AFFECTED} affected)"
-          git push
+
+          # A slice takes about ten minutes, so main can move while it runs.
+          # These files are generated, not authored, so rebasing and keeping
+          # ours is always the right answer for them.
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            echo "push rejected (attempt ${attempt}); rebasing onto the updated main"
+            git fetch origin main
+            git rebase -X ours origin/main || {
+              git rebase --abort
+              echo "could not rebase cleanly; leaving main alone"
+              exit 1
+            }
+          done
+          echo "still could not push after three attempts"
+          exit 1


### PR DESCRIPTION
## What happened

The 2026-08-13 crawl failed. Not in the scan, which finished the whole catalogue for the first time (**3089 scanned, 623 affected**), but at the last step:

```
[main 221ac83] chore(crawl): refresh index (3089 scanned, 623 affected)
 7 files changed, 8706 insertions(+), 1916 deletions(-)
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs
```

The job checks out main, scans for about ten minutes, then does a bare `git push`. I merged #10 and pushed the 1.4.1 release inside that window, so the push was a non-fast-forward and the job exited 1 with the entire slice discarded.

Nothing was corrupted, and no work is duplicated: `state/crawl.json` was never committed either, so the next run resumes from the last committed state. But a full-catalogue pass was thrown away, and this will happen again on any day someone merges around 04:00 UTC.

## The change

Push, and if it is rejected, rebase onto the updated main and retry, up to three times.

Every file the step commits is generated rather than authored (`docs/index.json`, `docs/index.html`, `docs/feed.xml`, `data/*.json`, `state/*.json`), so `-X ours` is the right resolution for them: the fresh crawl output should win over whatever the previous commit held. A rebase that cannot apply cleanly aborts and leaves main untouched rather than forcing anything.

## Note

The catalogue is 3088 repositories and the failed run reported 3089 scanned, which is one more than the catalogue total. Worth a look separately; it is a counting question, not a crawl failure, and it does not belong in this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)