### PR TITLE
Do not count delisted repositories as scanned

### DIFF
--- a/tests/test_build_index.py
+++ b/tests/test_build_index.py
@@ -102,6 +102,7 @@ def test_coverage_counts(payload):
     assert payload["coverage"] == {
         "catalog_total": 3,
         "repos_scanned": 3,
+        "repos_delisted": 0,
         "repos_affected": 1,
         "repos_clean": 1,
         "repos_unreachable": 1,
@@ -205,3 +206,27 @@ def test_published_index_is_valid_and_real(repo_root):
     for integration in published["integrations"]:
         assert "/" in integration["full_name"]
         assert not integration["full_name"].startswith("example/")
+
+
+def test_coverage_never_claims_more_scanned_than_the_catalogue_holds():
+    """A repository that is renamed or delisted keeps its findings record, so
+    counting the findings file made repos_scanned exceed catalog_total.
+
+    Seen live: drake69/NeverDry became never-dry/NeverDry, and the crawl
+    reported 3089 scanned against a 3088 repository catalogue.
+    """
+    from tools.build_index import build_payload
+
+    rules_doc = {"core_version": "2026.9", "rules": []}
+    catalog_doc = {"integrations": [{"full_name": "owner/still-listed", "domain": "a"}]}
+    findings_doc = {
+        "repos": {
+            "owner/still-listed": {"status": "scanned", "domain": "a", "findings": []},
+            "owner/renamed-away": {"status": "scanned", "domain": "b", "findings": []},
+        }
+    }
+
+    coverage = build_payload(rules_doc, findings_doc, catalog_doc)["coverage"]
+    assert coverage["repos_scanned"] == 1
+    assert coverage["repos_delisted"] == 1
+    assert coverage["repos_scanned"] <= coverage["catalog_total"]

--- a/tools/build_index.py
+++ b/tools/build_index.py
@@ -186,7 +186,11 @@ def build_payload(
         "catalog_source": catalog_doc.get("source", ""),
         "coverage": {
             "catalog_total": len(catalog_by_name),
-            "repos_scanned": len(repos),
+            # Only repositories still in the catalogue. A renamed or delisted
+            # repository keeps its findings record, so counting the file
+            # itself can exceed catalog_total and read as nonsense.
+            "repos_scanned": len(set(repos) & set(catalog_by_name)),
+            "repos_delisted": len(set(repos) - set(catalog_by_name)),
             "repos_affected": len(integrations),
             "repos_clean": len(clean_domains),
             "repos_unreachable": len(unreachable),


### PR DESCRIPTION
Noticed while investigating the failed crawl: it reported **3089 scanned against a 3088 repository catalogue**, which is impossible on its face.

`repos_scanned` counted records in `data/findings.json`, and a repository that leaves the catalogue keeps its record. `drake69/NeverDry` was renamed to `never-dry/NeverDry` on 08-09, so its old entry stayed behind and inflated the count.

`repos_scanned` now counts only repositories still in the catalogue, and a new `repos_delisted` reports the remainder instead of hiding it. That matters because `coverage` is the number the README points at to be honest about how much of the catalogue has actually been visited, so it should never be able to exceed the catalogue itself.

The stale record is harmless otherwise: it is a real scan of a real repository, it simply has a name nobody uses any more. It ages out when the crawl next rebuilds its state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)