### PR TITLE
chore: switch on the GitHub features this repo wasn't using

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalise to LF in the repository and in the working tree on every platform.
+# A Windows clone with core.autocrlf=true otherwise rewrites shebangs to CRLF,
+# and a publish from that clone ships a binary Linux rejects as "bad interpreter".
+* text=auto eol=lf

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: Booyaka101

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Something didn't work the way it should
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you ran, and what came back.
+      placeholder: |
+        $ python -m hass_breakage_radar ...
+        Traceback ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Breakage Radar version
+      description: The commit or release you are on.
+    validations:
+      required: true
+
+  - type: input
+    id: runtime
+    attributes:
+      label: Python version and OS
+      description: Output of `python --version`, plus your OS.
+      placeholder: Python 3.12.4 on Debian 12
+    validations:
+      required: true
+
+  - type: textarea
+    id: integration
+    attributes:
+      label: Which integration and which HA release
+      description: The custom integration's repo, and the Home Assistant version you expected the break in.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Home Assistant developer blog
+    url: https://developers.home-assistant.io/blog/
+    about: The deprecation announcements this tool tracks. Timing questions belong upstream.
+  - name: Home Assistant architecture discussions
+    url: https://github.com/home-assistant/architecture/discussions
+    about: Whether an API is actually going away, and when.
+  - name: Security issue
+    url: https://github.com/Booyaka101/hass-breakage-radar/security/advisories/new
+    about: Please report vulnerabilities privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest something hass-breakage-radar should do
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Reads public Home Assistant sources and integration repos over HTTPS. It never touches your Home Assistant instance or its config.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The situation, not the solution. What got in your way?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like it to do?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What are you doing instead today?
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## What this changes
+
+<!-- And why. Link an issue if there is one. -->
+
+## How you verified it
+
+<!--
+Be specific, and keep the claims separate — they carry different weight:
+  - `python -m pytest` passes
+  - ran it against a real project
+  - added a test case covering this
+-->
+
+## Checklist
+
+- [ ] `python -m pytest` passes
+- [ ] Added or updated a test for this change
+- [ ] Updated `README.md` if behaviour changed
+- [ ] Added a `CHANGELOG.md` entry under "Unreleased"
+- [ ] No credentials, tokens or personal data in the diff or in pasted output

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+# Staying current is a standing requirement, so it is automated rather than
+# remembered.
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      # Minor and patch only. Majors deliberately arrive as their own PR so one
+      # breaking upgrade cannot redden, and block, a batch of safe ones.
+      all-minor-patch:
+        patterns: ['*']
+        update-types: ['minor', 'patch']
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'chore(ci)'
+    groups:
+      # Minor and patch only. Majors deliberately arrive as their own PR so one
+      # breaking upgrade cannot redden, and block, a batch of safe ones.
+      actions-minor-patch:
+        patterns: ['*']
+        update-types: ['minor', 'patch']
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported versions
+
+The latest published version is the only one that gets fixes.
+
+## Reporting a vulnerability
+
+Please **don't** open a public issue for a security problem.
+
+Use GitHub's [private vulnerability reporting](https://github.com/Booyaka101/hass-breakage-radar/security/advisories/new) instead. Expect a first response within a week.
+
+Please include what you found, how to reproduce it, and what an attacker gets out of it.
+
+## What this touches
+
+Reads public Home Assistant sources and integration repos over HTTPS. It never touches your Home Assistant instance or its config.
+
+- **It never touches your Home Assistant instance.** It reads public sources over HTTPS: Home Assistant core, the developer blog and the integration repositories you name.
+
+## Scope
+
+In scope: anything that leaks a credential, reads data belonging to someone else, or lets untrusted input reach code execution.
+
+Out of scope: findings that require an attacker to already control the machine it runs on.


### PR DESCRIPTION
Repo hygiene sweep. Nothing here changes what the tool does.

- `.gitattributes`
- `.github/FUNDING.yml`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/dependabot.yml`
- `SECURITY.md`

Applied outside the diff, through the API, on this repo:

- Dependabot alerts and automated security fixes
- Secret scanning with push protection
- Private vulnerability reporting, which is what `SECURITY.md` now links to
- CodeQL default setup, including the `actions` language so the workflows get scanned too
- Delete branch on merge, allow auto-merge, allow update branch
- Wiki tab off (it was empty), homepage set to the package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)