### PR TITLE
fix(crawl): stop the daily rule-set rewrite from disabling CI on open PRs

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -79,9 +79,21 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/rules.json data/catalog.json data/findings.json \
+          git add data/catalog.json data/findings.json \
                   state/crawl.json state/feed.json \
                   docs/index.json docs/index.html docs/feed.xml docs/.nojekyll
+
+          # The rule set is rebuilt every run, so its provenance stamps move
+          # daily even when no rule did. Committing that keeps the file in
+          # conflict with every open pull request that touches it, and GitHub
+          # skips pull_request workflows on a conflicted PR -- the checks do
+          # not fail, they never run. The published index carries the rules
+          # either way.
+          if python tools/rules_changed.py; then
+            git add data/rules.json
+          else
+            git checkout -- data/rules.json
+          fi
           if git diff --cached --quiet; then
             echo "No index changes to commit."
             exit 0

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,6 +3,35 @@
 Status at the end of the v1.5.0 session (2026-08-17); earlier sections are kept
 as history, newest first.
 
+## The daily crawl was silently switching off CI on open PRs (2026-08-17)
+
+Noticed while shipping 1.5.0: two of the five pushes to that branch produced no
+`Validate` run at all, while the other three ran normally. Not a failure, no
+run. It looks exactly like a branch whose checks are green, because the only
+thing left on the commit is CodeQL, which runs on push.
+
+Cause, and the correlation is 5 for 5: the crawl commits `data/rules.json`
+every day. The rule set itself rarely changes, but `generated_utc`,
+`blog_merged_utc` and `core_tarball_sha256` move on every run, so any open pull
+request that touches the file conflicts within a day. **GitHub cannot build
+`refs/pull/N/merge` for a conflicted pull request, so it skips that PR's
+`pull_request` workflows entirely.** The two pushes made while the branch was
+conflicted got nothing; the three made while it was mergeable all ran.
+
+Fixed by not committing a provenance-only rewrite: `tools/rules_changed.py`
+compares the regenerated file against the committed one ignoring those stamps,
+and the crawl stages `data/rules.json` only when a rule really changed.
+Verified on the real file, where a fresh `blog_rules.py` run produces exactly
+one changed line and the tool correctly declines it.
+
+Not a release: the shipped integration is unchanged, so there is nothing for a
+user to update to. The published index carries the rules either way, and
+`build_index.py` stamps it with its own timestamp, so the board stays dated
+daily as before.
+
+Worth keeping in mind: a conflicted PR cannot be merged anyway, so nothing
+could have shipped unchecked. The cost was diagnostic, not correctness.
+
 ## v1.5.0 — DeviceEntry.config_entries finally has a matcher (2026-08-17)
 
 The one device-registry rule shipped `matchable: false` (the name collides with

--- a/tests/test_rules_changed.py
+++ b/tests/test_rules_changed.py
@@ -1,0 +1,53 @@
+"""A daily provenance-only rewrite must not land as a commit.
+
+Committing it conflicts with every open pull request that touches the file,
+and a conflicted pull request gets no `pull_request` workflow run at all.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tools.rules_changed import main, rules_changed
+
+BASE = {
+    "schema": 1,
+    "core_version": "2026.9",
+    "generated_utc": "2026-08-16T03:33:36Z",
+    "blog_merged_utc": "2026-08-16T03:34:01Z",
+    "core_tarball_sha256": "84b2adaa",
+    "counts": {"total": 143, "matchable_future": 35},
+    "rules": [{"id": "a", "breaks_in": "2027.8"}],
+}
+
+
+def test_a_new_day_alone_is_not_a_change():
+    later = {
+        **BASE,
+        "generated_utc": "2026-08-17T03:33:37Z",
+        "blog_merged_utc": "2026-08-17T03:34:02Z",
+        "core_tarball_sha256": "869ef45d",
+    }
+    assert rules_changed(BASE, later) is False
+
+
+def test_a_real_rule_edit_is_a_change():
+    edited = {**BASE, "rules": [{"id": "a", "breaks_in": "2027.9"}]}
+    added = {**BASE, "rules": BASE["rules"] + [{"id": "b", "breaks_in": "2027.8"}]}
+    counted = {**BASE, "counts": {"total": 144, "matchable_future": 36}}
+    assert rules_changed(BASE, edited) is True
+    assert rules_changed(BASE, added) is True
+    assert rules_changed(BASE, counted) is True
+
+
+def test_nothing_to_compare_against_counts_as_changed():
+    assert rules_changed(None, BASE) is True
+
+
+def test_cli_exit_codes(tmp_path):
+    """0 means commit it, 1 means leave it alone. `--against` cannot resolve
+    here, so the payload is uncomparable and the safe answer is to commit."""
+    path = tmp_path / "rules.json"
+    path.write_text(json.dumps(BASE), encoding="utf-8")
+    assert main(["--path", str(path), "--against", "HEAD"]) == 0
+    assert main(["--path", str(tmp_path / "absent.json")]) == 1

--- a/tools/rules_changed.py
+++ b/tools/rules_changed.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Has the rule set actually changed, or only its provenance stamps?
+
+The crawl regenerates ``data/rules.json`` on every run, so ``generated_utc``,
+``blog_merged_utc`` and the core tarball's sha move daily even when no rule
+did. Committing that keeps the file in conflict with every open pull request
+that touches it, and GitHub cannot build the merge ref for a conflicted pull
+request, so it skips the ``pull_request`` workflows for it. The checks do not
+fail, they never run, which reads exactly like a green branch.
+
+Exits 0 when the rules really changed and the file is worth committing, 1 when
+only the stamps moved.
+
+Usage::
+
+    python tools/rules_changed.py [--path data/rules.json] [--against HEAD]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools.common import DATA_DIR, LOGGER, setup_logging  # noqa: E402
+
+#: Keys that move on every run without saying anything about the rules. The
+#: counts are derived from the rules themselves, so they are not listed here.
+PROVENANCE_KEYS = frozenset(
+    {
+        "generated_utc",
+        "blog_merged_utc",
+        "core_tarball_sha256",
+        "core_files_scanned",
+        "core_files_unparsed",
+        "python_version",
+    }
+)
+
+
+def significant(payload: dict[str, Any]) -> dict[str, Any]:
+    """The part of a rules payload worth committing a change for."""
+    return {k: v for k, v in payload.items() if k not in PROVENANCE_KEYS}
+
+
+def rules_changed(previous: dict[str, Any] | None, current: dict[str, Any]) -> bool:
+    """True when ``current`` differs from ``previous`` in more than provenance.
+
+    A missing or unreadable previous payload counts as changed: committing a
+    file nobody can compare against is the safe direction.
+    """
+    if previous is None:
+        return True
+    return significant(previous) != significant(current)
+
+
+def committed_payload(path: Path, ref: str) -> dict[str, Any] | None:
+    """``path`` as of ``ref``, or ``None`` if it is not there or not readable."""
+    try:
+        blob = subprocess.run(
+            ["git", "show", f"{ref}:{path.as_posix()}"],
+            capture_output=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    try:
+        return json.loads(blob.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--path", type=Path, default=DATA_DIR / "rules.json")
+    parser.add_argument("--against", default="HEAD", help="git ref to compare with")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+    setup_logging(args.verbose)
+
+    if not args.path.exists():
+        LOGGER.error("%s does not exist", args.path)
+        return 1
+
+    current = json.loads(args.path.read_text(encoding="utf-8"))
+    relative = args.path
+    try:
+        relative = args.path.resolve().relative_to(Path.cwd().resolve())
+    except ValueError:
+        pass
+    previous = committed_payload(relative, args.against)
+
+    if rules_changed(previous, current):
+        LOGGER.info("%s: the rule set changed", args.path)
+        return 0
+    LOGGER.info("%s: only provenance moved; leaving it out of the commit", args.path)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`data/rules.json` is regenerated on every crawl, so `generated_utc`, `blog_merged_utc` and `core_tarball_sha256` move daily even when no rule changed. Committing that leaves the file in conflict with any open PR that touches it, and **GitHub cannot build `refs/pull/N/merge` for a conflicted PR, so it skips that PR's `pull_request` workflows entirely.** The checks do not fail, they never run, which looks exactly like a green branch since only CodeQL (push-triggered) is left on the commit.

Measured on the 1.5.0 branch, correlation 5 for 5:

| push | PR state | Validate run |
|---|---|---|
| `ec6926b` | conflicted | none |
| `a5bf9b9` | mergeable | ran |
| `89ce147` | mergeable | ran |
| `9602f44` | conflicted (crawl had pushed `cf1aeb6`) | none |
| `e439848` | mergeable | ran |

`tools/rules_changed.py` compares the regenerated file against the committed one ignoring those stamps, and the crawl now stages `data/rules.json` only when a rule really changed. Verified against the real file: a fresh `blog_rules.py` run produces exactly one changed line (`blog_merged_utc`) and the tool correctly declines to commit it.

The published index carries the rules either way, and `build_index.py` stamps it with its own timestamp, so the board stays dated daily as before.

No version bump. The shipped integration is untouched, so there is nothing for a user to update to.

Worth noting for the record: a conflicted PR cannot be merged, so nothing could have shipped unchecked. The cost here was diagnostic, not correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)