### PR TITLE
Let users ignore integrations they do not want reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
+## Unreleased
+
+### An ignore list in the options
+
+A second setting under **Configure** takes integrations to leave out of the
+report. Anything on it produces no finding, no notification and no count. The
+list starts empty and nothing is excluded on a user's behalf.
+
+It came from a request to drop HACS from the results. HACS is genuinely
+affected, it calls `device_registry.async_get_device` in
+`repositories/base.py` and that goes away in Core 2027.8, so excluding it by
+default would mean hiding a true positive. Everyone installs Breakage Radar
+through HACS though, so that single finding reaches every user and none of them
+can act on it. Letting each user decide keeps the default honest.
+
+The picker offers the domains actually affected on that system rather than the
+catalogue, so it is a handful of rows. It carries whatever is already ignored,
+since an ignored domain is filtered out of the report and would otherwise
+disappear from the list that ignores it, and it accepts values outside its own
+options so a stored entry survives the integration being fixed upstream and
+dropping off the affected list.
+
+`sensor.breakage_radar_affected` gained an `ignored_domains` attribute, and
+diagnostics reports the setting, so a missing integration reads as a choice
+rather than a bug.
+
 ## 1.5.0 — 2026-08-17
 
 ### `DeviceEntry.config_entries` is now detected

--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ Assistant install.
 Copy `custom_components/breakage_radar/` into your Home Assistant `config/custom_components/`
 directory and restart, then add the integration from the UI.
 
-The config flow has a single confirmation step. One setting is available afterwards
-under **Configure**: how far ahead a deadline gets its own notification.
+The config flow has a single confirmation step. Two settings are available afterwards
+under **Configure**: how far ahead a deadline gets its own notification, and any
+integrations you want left out of the report entirely.
 
 ### What you get
 
@@ -202,6 +203,11 @@ lists every date anyway.
 <p align="center">
   <img src="https://raw.githubusercontent.com/Booyaka101/hass-breakage-radar/main/images/options.png" alt="The options dialog, choosing how far ahead to be alerted" width="760">
 </p>
+
+The same dialog takes a list of integrations to leave out. It offers whatever is
+currently reported on your system, and anything you pick stops producing findings,
+notifications and counts altogether. Nothing is ever excluded on your behalf: the
+list starts empty, including for HACS itself, which is affected like anything else.
 
 The point of the split is that Repairs has no snooze button. A dozen cards for
 deadlines a year away would only teach you to ignore the panel — which is where every

--- a/custom_components/breakage_radar/__init__.py
+++ b/custom_components/breakage_radar/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import issue_registry as ir
 from .const import (
     ALERT_WINDOW_DAYS,
     CONF_ALERT_WINDOW_DAYS,
+    CONF_IGNORED_DOMAINS,
     DOMAIN,
     ISSUE_ID,
 )
@@ -34,6 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         alert_window_days=entry.options.get(
             CONF_ALERT_WINDOW_DAYS, ALERT_WINDOW_DAYS
         ),
+        ignored_domains=entry.options.get(CONF_IGNORED_DOMAINS) or (),
     )
     await coordinator.async_config_entry_first_refresh()
 
@@ -55,7 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Apply a changed alert window without needing a restart."""
+    """Apply changed options without needing a restart."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/custom_components/breakage_radar/config_flow.py
+++ b/custom_components/breakage_radar/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     ALERT_WINDOW_CHOICES,
     ALERT_WINDOW_DAYS,
     CONF_ALERT_WINDOW_DAYS,
+    CONF_IGNORED_DOMAINS,
     DOMAIN,
     INDEX_URL,
     NAME,
@@ -55,7 +56,18 @@ class BreakageRadarConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class BreakageRadarOptionsFlow(OptionsFlow):
-    """How far ahead a deadline is worth its own notification."""
+    """How far ahead a deadline is worth its own notification, and what to skip."""
+
+    def _ignorable_domains(self) -> list[str]:
+        """What the ignore list offers: affected domains, plus what is ignored.
+
+        An ignored domain is dropped from the report, so without the union it
+        would disappear from the very picker that ignores it.
+        """
+        coordinator = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id)
+        report = getattr(coordinator, "data", None) or {}
+        ignored = self.config_entry.options.get(CONF_IGNORED_DOMAINS) or []
+        return sorted({*report.get("affected_domains", []), *ignored})
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -63,7 +75,8 @@ class BreakageRadarOptionsFlow(OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(
                 data={
-                    CONF_ALERT_WINDOW_DAYS: int(user_input[CONF_ALERT_WINDOW_DAYS])
+                    CONF_ALERT_WINDOW_DAYS: int(user_input[CONF_ALERT_WINDOW_DAYS]),
+                    CONF_IGNORED_DOMAINS: user_input.get(CONF_IGNORED_DOMAINS) or [],
                 }
             )
 
@@ -80,7 +93,23 @@ class BreakageRadarOptionsFlow(OptionsFlow):
                         mode=SelectSelectorMode.DROPDOWN,
                         translation_key=CONF_ALERT_WINDOW_DAYS,
                     )
-                )
+                ),
+                vol.Optional(
+                    CONF_IGNORED_DOMAINS,
+                    default=self.config_entry.options.get(CONF_IGNORED_DOMAINS)
+                    or [],
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=self._ignorable_domains(),
+                        multiple=True,
+                        # A domain fixed upstream drops off the affected list.
+                        # Without this its stored entry is not a valid option
+                        # any more and the selector would silently discard it,
+                        # un-ignoring the integration if it ever regresses.
+                        custom_value=True,
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )
+                ),
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/breakage_radar/const.py
+++ b/custom_components/breakage_radar/const.py
@@ -36,6 +36,10 @@ CONF_ALERT_WINDOW_DAYS: Final = "alert_window_days"
 #: Offered in the options flow, in days.
 ALERT_WINDOW_CHOICES: Final = (30, 60, 90, 180, 365)
 
+#: Domains the user does not want reported at all. Empty by default; nothing is
+#: ever excluded on their behalf.
+CONF_IGNORED_DOMAINS: Final = "ignored_domains"
+
 #: However wide the window, only the nearest few deadlines get their own
 #: notification. The rest stay in the summary, which lists every date anyway.
 MAX_ALERT_CARDS: Final = 5

--- a/custom_components/breakage_radar/coordinator.py
+++ b/custom_components/breakage_radar/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any
 
@@ -41,6 +42,7 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         hass: HomeAssistant,
         index_url: str = INDEX_URL,
         alert_window_days: int = ALERT_WINDOW_DAYS,
+        ignored_domains: Iterable[str] = (),
     ) -> None:
         super().__init__(
             hass,
@@ -50,6 +52,7 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.index_url = index_url
         self.alert_window_days = alert_window_days
+        self.ignored_domains = tuple(ignored_domains)
         self.last_error: str | None = None
         self._index: dict[str, Any] | None = None
         #: ``domain -> (signature, result)``; lets the 12-hourly refresh skip
@@ -142,6 +145,7 @@ class BreakageRadarCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             current_version=current_version,
             today=datetime.now(UTC).date(),
             alert_window_days=self.alert_window_days,
+            ignored_domains=self.ignored_domains,
         )
         _LOGGER.debug(
             "Breakage Radar: %d of %d custom integrations affected "

--- a/custom_components/breakage_radar/diagnostics.py
+++ b/custom_components/breakage_radar/diagnostics.py
@@ -31,7 +31,10 @@ async def async_get_config_entry_diagnostics(
             "core_version": report.get("index_core_version"),
             "schema": report.get("index_schema"),
         },
-        "settings": {"alert_window_days": coordinator.alert_window_days},
+        "settings": {
+            "alert_window_days": coordinator.alert_window_days,
+            "ignored_domains": report.get("ignored_domains"),
+        },
         "scan": {
             "enabled": report.get("local_scan_enabled"),
             "files_scanned": report.get("files_scanned"),

--- a/custom_components/breakage_radar/report.py
+++ b/custom_components/breakage_radar/report.py
@@ -7,6 +7,7 @@ scanning in :mod:`.scanner`.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import date, timedelta
 from typing import Any
 
@@ -87,6 +88,7 @@ def build_report(
     current_version: str = "",
     today: date | None = None,
     alert_window_days: int = ALERT_WINDOW_DAYS,
+    ignored_domains: Iterable[str] = (),
 ) -> dict[str, Any]:
     """Match installed custom integrations against the published index.
 
@@ -100,8 +102,19 @@ def build_report(
     (release estimated within ``alert_window_days``) or ``upcoming``. Without
     a version or a date everything degrades to ``upcoming``.
 
+    Domains in ``ignored_domains`` are dropped before anything is levelled, so
+    the user's own choice never shows up as a finding, a notification or a count.
+
     A malformed index gives an empty report rather than raising.
     """
+    # Before any other work, so every count downstream agrees on what is in play.
+    ignored = set(ignored_domains) & installed.keys()
+    installed = {
+        domain: version
+        for domain, version in installed.items()
+        if domain not in ignored
+    }
+
     rules = {
         rule["id"]: rule
         for rule in index.get("rules", [])
@@ -287,6 +300,7 @@ def build_report(
             set(affected) - set(broken_now) - set(imminent)
         ),
         "alert_window_days": alert_window_days,
+        "ignored_domains": sorted(ignored),
         "files_scanned": (local_scan or {}).get("files_scanned", 0),
         "unparsed_files": (local_scan or {}).get("unparsed_files", 0),
         "skipped_files": (local_scan or {}).get("skipped_files", 0),

--- a/custom_components/breakage_radar/sensor.py
+++ b/custom_components/breakage_radar/sensor.py
@@ -97,6 +97,7 @@ class BreakageRadarSensor(CoordinatorEntity[BreakageRadarCoordinator], SensorEnt
             "imminent_count": data.get("imminent_count", 0),
             "earliest_release": data.get("earliest_release"),
             "alert_window_days": data.get("alert_window_days", 0),
+            "ignored_domains": data.get("ignored_domains", []),
             "total_findings": data.get("total_findings", 0),
             "details_truncated": data.get("total_findings", 0) > len(findings),
             "installed_count": data.get("installed_count", 0),

--- a/custom_components/breakage_radar/strings.json
+++ b/custom_components/breakage_radar/strings.json
@@ -17,10 +17,12 @@
         "title": "Breakage Radar options",
         "description": "An integration breaking inside the alert window gets its own notification. Everything further out is listed together in one summary, so a deadline a year away doesn't sit in your notifications for months.",
         "data": {
-          "alert_window_days": "Alert me this far ahead"
+          "alert_window_days": "Alert me this far ahead",
+          "ignored_domains": "Integrations to leave out"
         },
         "data_description": {
-          "alert_window_days": "Home Assistant releases once a month, on the first Wednesday, so each 30 days is roughly one release of warning."
+          "alert_window_days": "Home Assistant releases once a month, on the first Wednesday, so each 30 days is roughly one release of warning.",
+          "ignored_domains": "Nothing is reported for these: no notification, no finding, and they stay out of the counts. The list offers the integrations currently reported on this system. Empty unless you add something."
         }
       }
     }

--- a/custom_components/breakage_radar/translations/en.json
+++ b/custom_components/breakage_radar/translations/en.json
@@ -17,10 +17,12 @@
         "title": "Breakage Radar options",
         "description": "An integration breaking inside the alert window gets its own notification. Everything further out is listed together in one summary, so a deadline a year away doesn't sit in your notifications for months.",
         "data": {
-          "alert_window_days": "Alert me this far ahead"
+          "alert_window_days": "Alert me this far ahead",
+          "ignored_domains": "Integrations to leave out"
         },
         "data_description": {
-          "alert_window_days": "Home Assistant releases once a month, on the first Wednesday, so each 30 days is roughly one release of warning."
+          "alert_window_days": "Home Assistant releases once a month, on the first Wednesday, so each 30 days is roughly one release of warning.",
+          "ignored_domains": "Nothing is reported for these: no notification, no finding, and they stay out of the counts. The list offers the integrations currently reported on this system. Empty unless you add something."
         }
       }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,8 @@ def _install_homeassistant_stubs() -> None:
     core = module("homeassistant.core")
 
     class HomeAssistant:  # noqa: D101
-        pass
+        def __init__(self):
+            self.data: dict = {}
 
     def callback(func):  # noqa: D103
         return func
@@ -75,6 +76,8 @@ def _install_homeassistant_stubs() -> None:
 
     class OptionsFlow(_FlowBase):  # noqa: D101
         config_entry = ConfigEntry()
+        #: Home Assistant has always set this by the time a step runs.
+        hass = HomeAssistant()
 
     config_entries.ConfigEntry = ConfigEntry
     config_entries.ConfigFlow = ConfigFlow
@@ -88,10 +91,20 @@ def _install_homeassistant_stubs() -> None:
         LIST = "list"
 
     class SelectSelectorConfig:  # noqa: D101
-        def __init__(self, options=None, mode=None, translation_key=None, **kwargs):
+        def __init__(
+            self,
+            options=None,
+            mode=None,
+            translation_key=None,
+            multiple=False,
+            custom_value=False,
+            **kwargs,
+        ):
             self.options = options or []
             self.mode = mode
             self.translation_key = translation_key
+            self.multiple = multiple
+            self.custom_value = custom_value
 
     class SelectSelector:  # noqa: D101
         def __init__(self, config):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -57,7 +57,7 @@ def test_options_flow_stores_the_window_as_an_int():
 
     assert result["type"] == "create_entry"
     # A selector hands back a string; the coordinator does date maths with it.
-    assert result["data"] == {CONF_ALERT_WINDOW_DAYS: 180}
+    assert result["data"][CONF_ALERT_WINDOW_DAYS] == 180
     assert isinstance(result["data"][CONF_ALERT_WINDOW_DAYS], int)
 
 

--- a/tests/test_ignore_list.py
+++ b/tests/test_ignore_list.py
@@ -1,0 +1,205 @@
+"""The per-user ignore list (issue #19).
+
+HACS is the case that prompted it: everyone who installs Breakage Radar
+installs it through HACS, so a real finding against HACS itself reaches every
+user and none of them can act on it. The answer is to let the user drop it
+rather than to exclude anything on their behalf, so the default here is empty
+and the tests below mostly guard "ignoring one thing changes nothing else".
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.breakage_radar.config_flow import BreakageRadarOptionsFlow
+from custom_components.breakage_radar.const import (
+    CONF_ALERT_WINDOW_DAYS,
+    CONF_IGNORED_DOMAINS,
+    DOMAIN,
+)
+from custom_components.breakage_radar.report import build_report
+
+INSTALLED = {"fixture_tracker": "0.1.0", "lookalike_tracker": "0.1.0"}
+
+
+def _report(index, installed=None, **kwargs):
+    return build_report(index, dict(installed or INSTALLED), **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# the report
+# --------------------------------------------------------------------------- #
+
+
+def test_nothing_is_ignored_by_default(sample_index):
+    report = _report(sample_index)
+
+    assert report["ignored_domains"] == []
+    assert report["affected_domains"] == ["fixture_tracker"]
+
+
+def test_an_ignored_domain_leaves_no_trace_in_the_report(sample_index):
+    report = _report(sample_index, ignored_domains=["fixture_tracker"])
+
+    assert report["ignored_domains"] == ["fixture_tracker"]
+    assert report["affected_count"] == 0
+    assert report["affected_domains"] == []
+    assert report["details"] == []
+    assert report["total_findings"] == 0
+    assert report["schedule"] == []
+    assert report["earliest_release"] is None
+
+
+def test_ignoring_one_integration_leaves_the_others_alone(sample_index):
+    report = _report(sample_index, ignored_domains=["lookalike_tracker"])
+
+    assert report["ignored_domains"] == ["lookalike_tracker"]
+    assert report["affected_domains"] == ["fixture_tracker"]
+    assert "lookalike_tracker" not in report["clean_domains"]
+
+
+def test_an_ignored_domain_is_out_of_the_counts_entirely(sample_index):
+    """Not just hidden from the list: the "n of m" has to agree with it."""
+    both = _report(sample_index)
+    one = _report(sample_index, ignored_domains=["fixture_tracker"])
+
+    assert both["installed_count"] == 2
+    assert one["installed_count"] == 1
+
+
+def test_ignoring_something_that_is_not_installed_does_nothing(sample_index):
+    report = _report(sample_index, ignored_domains=["never_installed"])
+
+    assert report["ignored_domains"] == []
+    assert report["affected_domains"] == ["fixture_tracker"]
+
+
+def test_an_ignored_domain_raises_no_alert_however_urgent(sample_index):
+    """The levelling runs after the filter, so even "broken now" stays quiet."""
+    loud = _report(sample_index, current_version="2027.5", today=date(2027, 5, 5))
+    assert loud["broken_now"] == {"fixture_tracker": "2027.5"}
+
+    quiet = _report(
+        sample_index,
+        current_version="2027.5",
+        today=date(2027, 5, 5),
+        ignored_domains=["fixture_tracker"],
+    )
+    assert quiet["broken_now"] == {}
+    assert quiet["imminent"] == {}
+    assert quiet["summarised_domains"] == []
+
+
+def test_an_ignored_domain_gets_no_repairs_card(sample_index):
+    from homeassistant.helpers import issue_registry as ir
+
+    from custom_components.breakage_radar.repairs import async_sync_issue
+
+    if not hasattr(ir, "created"):
+        pytest.skip("real Home Assistant installed; covered by HA's own harness")
+
+    ir.created.clear()
+    async_sync_issue(
+        None,
+        _report(
+            sample_index,
+            current_version="2027.5",
+            today=date(2027, 5, 5),
+            ignored_domains=["fixture_tracker"],
+        ),
+    )
+
+    assert not [key for key in ir.created if key[0] == DOMAIN]
+
+
+def test_the_sensor_says_what_is_being_left_out(sample_index):
+    """Otherwise a missing integration looks like a bug rather than a setting."""
+    from conftest import FakeCoordinator
+
+    from custom_components.breakage_radar.sensor import BreakageRadarSensor
+
+    report = _report(sample_index, ignored_domains=["fixture_tracker"])
+    sensor = BreakageRadarSensor(FakeCoordinator(report))
+
+    assert sensor.extra_state_attributes["ignored_domains"] == ["fixture_tracker"]
+    assert sensor.native_value == 0
+
+
+# --------------------------------------------------------------------------- #
+# the options flow
+# --------------------------------------------------------------------------- #
+
+
+def _flow(*, options=None, affected=None):
+    """A flow with its own entry and hass, so tests cannot leak into each other
+    through the shared stubs in conftest."""
+    flow = BreakageRadarOptionsFlow()
+    entry = SimpleNamespace(entry_id="test-entry", options=options or {})
+    coordinator = SimpleNamespace(data={"affected_domains": affected or []})
+    flow.config_entry = entry
+    flow.hass = SimpleNamespace(data={DOMAIN: {entry.entry_id: coordinator}})
+    return flow
+
+
+def _field(form, key):
+    schema = form["data_schema"].schema
+    marker = next(m for m in schema if m.schema == key)
+    return marker, schema[marker]
+
+
+def test_the_picker_offers_what_is_actually_affected():
+    form = asyncio.run(_flow(affected=["hacs", "pycupra"]).async_step_init())
+
+    _, selector = _field(form, CONF_IGNORED_DOMAINS)
+    assert selector.config.options == ["hacs", "pycupra"]
+    assert selector.config.multiple is True
+
+
+def test_an_already_ignored_domain_stays_in_the_picker():
+    """It is filtered out of the report, so the union is the only thing
+    keeping it visible in the list that put it there."""
+    form = asyncio.run(
+        _flow(
+            options={CONF_IGNORED_DOMAINS: ["hacs"]}, affected=["pycupra"]
+        ).async_step_init()
+    )
+
+    marker, selector = _field(form, CONF_IGNORED_DOMAINS)
+    assert selector.config.options == ["hacs", "pycupra"]
+    assert marker.default == ["hacs"]
+
+
+def test_a_stored_domain_survives_dropping_off_the_affected_list():
+    """Fixed upstream today, regressed in six months. Without custom_value the
+    selector discards the stored value and the ignore is silently undone."""
+    form = asyncio.run(
+        _flow(options={CONF_IGNORED_DOMAINS: ["hacs"]}, affected=[]).async_step_init()
+    )
+
+    _, selector = _field(form, CONF_IGNORED_DOMAINS)
+    assert selector.config.custom_value is True
+
+
+def test_saving_keeps_both_settings():
+    flow = _flow(affected=["hacs"])
+    result = asyncio.run(
+        flow.async_step_init(
+            {CONF_ALERT_WINDOW_DAYS: "90", CONF_IGNORED_DOMAINS: ["hacs"]}
+        )
+    )
+
+    assert result["data"] == {
+        CONF_ALERT_WINDOW_DAYS: 90,
+        CONF_IGNORED_DOMAINS: ["hacs"],
+    }
+
+
+def test_saving_with_nothing_ignored_stores_an_empty_list():
+    flow = _flow()
+    result = asyncio.run(flow.async_step_init({CONF_ALERT_WINDOW_DAYS: "30"}))
+
+    assert result["data"][CONF_IGNORED_DOMAINS] == []


### PR DESCRIPTION
@
## What this changes

A second setting on the options flow: integrations to leave out of the report. Empty by default. Anything on the list produces no finding, no notification and no count.

Asked for on r/homeassistant (#19), where someone suggested excluding HACS from the results. HACS is genuinely affected, it calls `device_registry.async_get_device` in `repositories/base.py` and that goes away in Core 2027.8, so excluding it by default would mean hiding a true positive. Everyone installs Breakage Radar through HACS though, so that one finding reaches every user and none of them can act on it. Letting each user decide keeps the default honest and still answers the complaint.

Ignored domains are dropped at the top of `build_report`, before anything is levelled, so they leave nothing behind in one view while being filtered out of another. Two details that are easy to get wrong:

* The picker offers the domains actually affected on that system, not the catalogue, so it is a handful of rows. It is a union with what is already ignored, because an ignored domain is filtered out of the report and would otherwise vanish from the list that ignores it.
* `custom_value` is set, so a stored entry survives the integration being fixed upstream and dropping off the affected list. Without it the selector silently discards the value and the ignore is undone if that integration ever regresses.

`sensor.breakage_radar_affected` gained an `ignored_domains` attribute and diagnostics reports the setting, so a missing integration reads as a choice rather than a bug.

No version bump or release in this PR.

## How you verified it

* `python -m pytest` passes: 249 passed, 3 skipped, up from 236 on main.
* Added `tests/test_ignore_list.py`, 13 cases covering the report filter, the alert levels, the repairs cards, the sensor attribute and the options flow.
* Ran the branch in a real Home Assistant container against three genuinely affected integrations. The schema the frontend receives has `multiple: true` and `custom_value: true`; the picker offered only `beny_wifi`, `eveus` and `smappee_ev`; ignoring one took the sensor from 3 to 2 and `installed_count` from 4 to 3; the chip survived a restart; the summary schedule dropped to the remaining two.
* `ruff check` clean on every file touched. `ruff format` was not run, since `config_flow.py` and `report.py` already failed it on main and reformatting would bury the diff.

## Checklist

- [x] `python -m pytest` passes
- [x] Added or updated a test for this change
- [x] Updated `README.md` if behaviour changed
- [x] Added a `CHANGELOG.md` entry under "Unreleased"
- [x] No credentials, tokens or personal data in the diff or in pasted output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@