### PR TITLE
chore: release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
-## Unreleased
+## 1.6.0 — 2026-08-18
 
 ### An ignore list in the options
 

--- a/custom_components/breakage_radar/manifest.json
+++ b/custom_components/breakage_radar/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/Booyaka101/hass-breakage-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-breakage-radar"
-version = "1.5.0"
+version = "1.6.0"
 description = "Find out which of your Home Assistant custom integrations stop working, and in which future release."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Version bump and changelog date for the ignore list (#20, requested in #19).

`manifest.json` and `pyproject.toml` both go to 1.6.0, which `test_integration.py` enforces agreement on, and the CHANGELOG section moves from Unreleased to 1.6.0.

No behaviour change beyond what #20 already merged.

## How you verified it

* `python -m pytest` passes: 249 passed, 3 skipped.
* The feature itself was verified in a real Home Assistant container on #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)