### PR TITLE
Feed: one item per release, and render it in a browser

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -81,7 +81,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add data/catalog.json data/findings.json \
                   state/crawl.json state/feed.json \
-                  docs/index.json docs/index.html docs/feed.xml docs/.nojekyll
+                  docs/index.json docs/index.html docs/feed.xml docs/feed.xsl \
+                  docs/.nojekyll
 
           # The rule set is rebuilt every run, so its provenance stamps move
           # daily even when no rule did. Committing that keeps the file in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
+## Unreleased
+
+### The feed carries releases instead of bookmarks
+
+`feed.xml` published one item per rule, titled `2027.8: <symbol>` with a
+sentence of description and a link into home-assistant/core. A reader showed
+that as sixty bookmarks. Each item is now a Home Assistant release, carrying
+what that release removes and which HACS integrations still use it, and
+linking to that release's section of the board.
+
+The body carries the rule list in full plus the twenty most starred affected
+integrations. Embedding every affected integration would be 475 KB against a
+31 KB feed, four fifths of it 2027.8 alone, growing with every crawl. As
+built it is 27 925 bytes over five items, against 31 867 over sixty.
+
+An item is news when a rule joins its release. The integration count moves
+daily as the crawl widens, and dating items on that would re-notify every
+subscriber several times a day, so `pubDate` is the newest first-seen date
+among the release's rules. Nothing in `state/feed.json` had to change, so no
+existing subscription churns.
+
+Opening the feed in a browser now renders a page rather than raw XML. Feed
+readers ignore the stylesheet, so nothing about the XML changed for them.
+
+Nothing to update on a Home Assistant box: this is the published feed, not the
+integration.
+
 ## 1.6.0 — 2026-08-18
 
 ### An ignore list in the options

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ of **your** installed integrations are on the list and when they die.
 📊 **Board:** <https://booyaka101.github.io/hass-breakage-radar/>
 🤖 **Index:** <https://booyaka101.github.io/hass-breakage-radar/index.json> (schema 1)
 📡 **Feed:** <https://booyaka101.github.io/hass-breakage-radar/feed.xml> — one item per
-announced removal, so you can follow what Home Assistant is retiring without polling
-the index.
+Home Assistant release, carrying what that release removes and which integrations still
+use it, so you can follow along without polling the index. Paste it into a feed reader,
+or into Home Assistant's own `feedreader` integration; open it in a browser and it
+renders as a page.
 
 **In the published index right now:** 2 500 of the 3 088 HACS custom integrations
 crawled (18 unreachable), **508 affected**, **1 259 findings**, across 5 Home Assistant

--- a/docs/feed.xsl
+++ b/docs/feed.xsl
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Browsers show a feed as raw XML, which reads as broken to anyone who clicks
+  the link rather than subscribing. Readers ignore this stylesheet, so the XML
+  contract is unchanged; it only exists for the person who arrives in a browser.
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" encoding="UTF-8" indent="yes"/>
+
+  <xsl:template match="/rss/channel">
+    <html lang="en">
+      <head>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <title><xsl:value-of select="title"/></title>
+        <style>
+:root {
+  --bg:#0f1216; --panel:#171c22; --line:#262d36; --ink:#e6edf3;
+  --muted:#8b98a5; --accent:#38bdf8; --warn:#f59e0b;
+}
+@media (prefers-color-scheme: light) {
+  :root { --bg:#f6f8fa; --panel:#fff; --line:#d8dee4; --ink:#1f2328;
+          --muted:#57606a; --accent:#0969da; }
+}
+* { box-sizing:border-box; }
+body { margin:0; background:var(--bg); color:var(--ink);
+  font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+header { padding:32px 20px 12px; max-width:900px; margin:0 auto; }
+h1 { margin:0 0 6px; font-size:28px; letter-spacing:-.02em; }
+.sub { color:var(--muted); margin:0 0 18px; max-width:70ch; }
+main { max-width:900px; margin:0 auto; padding:0 20px 60px; }
+a { color:var(--accent); }
+.note { background:var(--panel); border:1px solid var(--line); border-radius:10px;
+  padding:14px 16px; margin:0 0 26px; color:var(--muted); font-size:14px; }
+.note code { color:var(--ink); background:rgba(127,127,127,.15);
+  padding:1px 5px; border-radius:5px; word-break:break-all; }
+article { border-top:1px solid var(--line); padding:22px 0; }
+article > h2 { font-size:19px; margin:0 0 2px;
+  display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
+.pill { font-size:12px; font-weight:600; padding:2px 9px; border-radius:999px;
+  background:var(--warn); color:#000; }
+.when { color:var(--muted); font-size:13px; margin:0 0 10px; }
+article h3 { font-size:13px; text-transform:uppercase; letter-spacing:.06em;
+  color:var(--muted); margin:18px 0 6px; }
+article ul { margin:6px 0 14px; padding-left:18px; font-size:14px; }
+article li { margin:5px 0; }
+table { width:100%; border-collapse:collapse; background:var(--panel);
+  border:1px solid var(--line); border-radius:10px; overflow:hidden; font-size:14px; }
+th, td { text-align:left; padding:7px 10px; border-bottom:1px solid var(--line); }
+th { color:var(--muted); font-size:12px; text-transform:uppercase; letter-spacing:.05em; }
+tr:last-child td { border-bottom:0; }
+footer { color:var(--muted); font-size:13px; padding:0 20px 40px;
+  max-width:900px; margin:0 auto; }
+        </style>
+      </head>
+      <body>
+        <header>
+          <h1><xsl:value-of select="title"/></h1>
+          <p class="sub"><xsl:value-of select="description"/></p>
+        </header>
+        <main>
+          <div class="note">
+            This is an <strong>RSS feed</strong>, meant for a feed reader rather than
+            a browser. Paste this address into yours to follow along:
+            <code><xsl:value-of select="atom:link/@href"
+              xmlns:atom="http://www.w3.org/2005/Atom"/></code>
+            Home Assistant's own <code>feedreader</code> integration takes it too, so
+            you can trigger an automation when a removal is announced. Everything
+            below is what the feed carries right now.
+          </div>
+          <xsl:apply-templates select="item"/>
+        </main>
+        <footer>
+          <p>
+            <a href="{link}">Breakage Radar board</a>
+            &#183; updated <xsl:value-of select="lastBuildDate"/>
+          </p>
+        </footer>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="item">
+    <article>
+      <!-- No release pill: the title already names it, and the lead sentence
+           below carries the count the board shows there. -->
+      <h2><a href="{link}"><xsl:value-of select="title"/></a></h2>
+      <p class="when">Announced <xsl:value-of select="pubDate"/></p>
+      <!-- The body is generated HTML in a CDATA block, so it goes out as markup. -->
+      <xsl:value-of select="description" disable-output-escaping="yes"/>
+    </article>
+  </xsl:template>
+</xsl:stylesheet>

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -1,7 +1,9 @@
 """The RSS feed of announced removals.
 
 Asked for on the announcement thread: following the index means diffing a
-snapshot yourself, so the feed answers "what is new" instead.
+snapshot yourself, so the feed answers "what is new" instead. One item per
+release, carrying that release's own content, because an item a reader can
+display beats a bookmark (#28).
 """
 
 from __future__ import annotations
@@ -10,36 +12,73 @@ import xml.etree.ElementTree as ET
 
 import pytest
 
-from tools.feed import MAX_ITEMS, MAX_TITLE, build, describe, title_for, update_first_seen
+from tools.feed import (
+    MAX_ITEMS,
+    MAX_LABEL,
+    MAX_TABLE_ROWS,
+    STYLESHEET,
+    build,
+    describe,
+    group_by_release,
+    guid_for,
+    published_for,
+    rule_label,
+    update_first_seen,
+)
+
+RULES = [
+    {
+        "id": "legacy-device-tracker-platform",
+        "breaks_in": "2027.5",
+        "symbol": "setup_scanner",
+        "message": "Implements the legacy device tracker platform API.",
+        "source": "https://developers.home-assistant.io/blog/legacy/",
+        "confidence": "high",
+        "replacement": "ScannerEntity",
+        "repos_hit": 11,
+    },
+    {
+        "id": "core-call-verify-domain-control",
+        "breaks_in": "2026.10",
+        "symbol": "verify_domain_control",
+        "message": "Passes hass where it is ignored.",
+        "source": "homeassistant/helpers/service.py:418",
+        "source_url": "https://github.com/home-assistant/core/blob/dev/x.py#L1",
+        "confidence": "medium",
+        "repos_hit": 1,
+    },
+]
+
+
+def _integration(name, domain, release, rule_id, stars=0):
+    return {
+        "full_name": name,
+        "domain": domain,
+        "version": "1.0.0",
+        "repo_url": f"https://github.com/{name}",
+        "stargazers_count": stars,
+        "findings": [
+            {"rule_id": rule_id, "breaks_in": release, "file": "x.py", "line": 1}
+        ],
+    }
 
 
 @pytest.fixture
 def payload():
     return {
         "generated_utc": "2026-08-12T04:00:00Z",
-        "rules": [
-            {
-                "id": "legacy-device-tracker-platform",
-                "breaks_in": "2027.5",
-                "symbol": "setup_scanner",
-                "message": "Implements the legacy device tracker platform API.",
-                "source": "https://developers.home-assistant.io/blog/legacy/",
-                "confidence": "high",
-                "replacement": "ScannerEntity",
-                "repos_hit": 11,
-            },
-            {
-                "id": "core-call-verify-domain-control",
-                "breaks_in": "2026.10",
-                "symbol": "verify_domain_control",
-                "message": "Passes hass where it is ignored.",
-                "source": "homeassistant/helpers/service.py:418",
-                "source_url": "https://github.com/home-assistant/core/blob/dev/x.py#L1",
-                "confidence": "medium",
-                "repos_hit": 1,
-            },
+        # Copied, or a test that appends a rule leaks into the next one.
+        "rules": [dict(rule) for rule in RULES],
+        "integrations": [
+            _integration("a/one", "one", "2027.5", "legacy-device-tracker-platform", 50),
+            _integration("b/two", "two", "2027.5", "legacy-device-tracker-platform", 10),
+            _integration("c/three", "three", "2026.10", "core-call-verify-domain-control"),
         ],
     }
+
+
+def _channel(feed):
+    return ET.fromstring(feed).find("channel")
 
 
 def test_the_feed_is_valid_rss(payload):
@@ -47,104 +86,258 @@ def test_the_feed_is_valid_rss(payload):
     channel = root.find("channel")
     assert root.get("version") == "2.0"
     assert channel.findtext("title").startswith("Breakage Radar")
-    assert len(channel.findall("item")) == 2
 
 
-def test_each_removal_is_one_item_with_a_stable_id(payload):
-    channel = ET.fromstring(build(payload, {})).find("channel")
-    guids = [i.findtext("guid") for i in channel.findall("item")]
-    assert guids == [
-        "breakage-radar:core-call-verify-domain-control",
-        "breakage-radar:legacy-device-tracker-platform",
+def test_one_item_per_release_not_per_rule(payload):
+    channel = _channel(build(payload, {}))
+    titles = [i.findtext("title") for i in channel.findall("item")]
+    assert titles == ["Home Assistant 2026.10", "Home Assistant 2027.5"]
+
+
+def test_an_item_links_to_its_own_section_of_the_board(payload):
+    channel = _channel(build(payload, {}))
+    links = [i.findtext("link") for i in channel.findall("item")]
+    assert links[0].endswith("#release-2026.10")
+    assert all(link.startswith("https://") for link in links)
+
+
+def test_the_body_carries_the_release_contents(payload):
+    channel = _channel(build(payload, {}))
+    body = channel.findall("item")[1].findtext("description")
+
+    # The rules, by symbol rather than by slug.
+    assert "setup_scanner" in body
+    assert "Implements the legacy device tracker platform API." in body
+    # The integrations, linked.
+    assert "https://github.com/a/one" in body
+    assert "<table>" in body
+    # And a way back to the whole list.
+    assert "#release-2027.5" in body
+
+
+def test_the_body_is_markup_not_escaped_text(payload):
+    """A reader showing &lt;table&gt; as text is the failure this guards."""
+    feed = build(payload, {})
+    assert "<![CDATA[" in feed
+    assert "&lt;table&gt;" not in feed
+
+
+def test_a_title_carries_no_count(payload):
+    """The count moves daily; a title that moves makes an unchanged item look
+    new in some readers."""
+    for item in _channel(build(payload, {})).findall("item"):
+        assert item.findtext("title").count(" ") == 2
+
+
+# --------------------------------------------------------------------------- #
+# what counts as news
+# --------------------------------------------------------------------------- #
+
+
+def test_a_release_is_dated_by_its_newest_rule():
+    seen = {"old": "2026-01-01T00:00:00Z", "new": "2026-08-01T00:00:00Z"}
+    rules = [{"id": "old"}, {"id": "new"}]
+    assert published_for(rules, seen, "2026-09-01T00:00:00Z") == "2026-08-01T00:00:00Z"
+
+
+def test_more_integrations_do_not_republish_a_release(payload):
+    """The crawl widens daily. If that moved the date, every subscriber would
+    be re-notified five times a day."""
+    seen = update_first_seen(payload["rules"], {}, now="2026-08-01T00:00:00Z")
+    before = _channel(build(payload, seen)).findall("item")
+
+    payload["integrations"].append(
+        _integration("d/four", "four", "2027.5", "legacy-device-tracker-platform", 99)
+    )
+    after = _channel(build(payload, seen)).findall("item")
+
+    assert [i.findtext("pubDate") for i in before] == [
+        i.findtext("pubDate") for i in after
     ]
-    # Same input, same ids, so a reader does not re-notify.
-    again = ET.fromstring(build(payload, {})).find("channel")
-    assert [i.findtext("guid") for i in again.findall("item")] == guids
+    assert [i.findtext("guid") for i in before] == [i.findtext("guid") for i in after]
 
 
-def test_the_soonest_deadline_comes_first_when_dates_tie(payload):
-    """Every rule shares a date on the first run, so ordering has to mean
-    something else."""
-    channel = ET.fromstring(build(payload, {})).find("channel")
-    assert [i.findtext("category") for i in channel.findall("item")] == [
-        "2026.10",
-        "2027.5",
-    ]
+def test_a_new_rule_resurfaces_its_release(payload):
+    seen = update_first_seen(payload["rules"], {}, now="2026-08-01T00:00:00Z")
+    was = _channel(build(payload, seen)).findall("item")[1]
+
+    payload["rules"].append(
+        {
+            "id": "brand-new",
+            "breaks_in": "2027.5",
+            "symbol": "something_else",
+            "message": "m",
+            "source": "s",
+            "confidence": "low",
+            "repos_hit": 0,
+        }
+    )
+    payload["integrations"].append(
+        _integration("e/five", "five", "2027.5", "brand-new")
+    )
+    seen = update_first_seen(payload["rules"], seen, now="2026-09-01T00:00:00Z")
+    now = _channel(build(payload, seen)).findall("item")[0]
+
+    assert now.findtext("title") == was.findtext("title")
+    assert now.findtext("pubDate") != was.findtext("pubDate")
+    # The guid folds in the rule set, so a reader treats it as new.
+    assert now.findtext("guid") != was.findtext("guid")
+
+
+def test_the_same_input_gives_the_same_guid(payload):
+    first = [i.findtext("guid") for i in _channel(build(payload, {})).findall("item")]
+    again = [i.findtext("guid") for i in _channel(build(payload, {})).findall("item")]
+    assert first == again
+    assert all(g.startswith("breakage-radar:release:") for g in first)
 
 
 def test_a_rule_keeps_the_date_it_was_first_published(payload):
     seen = update_first_seen(payload["rules"], {}, now="2026-08-01T00:00:00Z")
-    assert set(seen) == {"legacy-device-tracker-platform", "core-call-verify-domain-control"}
-
-    payload["rules"].append({
-        "id": "brand-new", "breaks_in": "2028.1", "symbol": "x",
-        "message": "m", "source": "s", "confidence": "low", "repos_hit": 0,
-    })
+    payload["rules"].append(
+        {"id": "brand-new", "breaks_in": "2028.1", "symbol": "x", "message": "m"}
+    )
     seen = update_first_seen(payload["rules"], seen, now="2026-09-01T00:00:00Z")
+
     assert seen["legacy-device-tracker-platform"] == "2026-08-01T00:00:00Z"
     assert seen["brand-new"] == "2026-09-01T00:00:00Z"
 
-    channel = ET.fromstring(build(payload, seen)).find("channel")
-    assert channel.findall("item")[0].findtext("category") == "2028.1"
+
+# --------------------------------------------------------------------------- #
+# size, which is why the table is capped
+# --------------------------------------------------------------------------- #
 
 
-def test_an_item_links_somewhere_a_browser_can_open(payload):
-    """A rule's source can be a bare 'file.py:418', which is not a URL."""
-    channel = ET.fromstring(build(payload, {})).find("channel")
-    for item in channel.findall("item"):
-        assert item.findtext("link").startswith("http")
-
-
-def test_the_description_says_how_many_integrations_are_affected(payload):
-    text = describe(payload["rules"][0], 11)
-    assert "11 integration(s)" in text
-    assert "ScannerEntity" in text
-
-
-def test_the_feed_is_capped(payload):
-    payload["rules"] = [
-        {**payload["rules"][0], "id": f"rule-{n:03d}", "breaks_in": f"2027.{n % 12 + 1}"}
-        for n in range(MAX_ITEMS + 20)
+def test_the_table_is_capped_and_says_so(payload):
+    payload["integrations"] += [
+        _integration(f"x/repo{n}", f"d{n}", "2027.5", "legacy-device-tracker-platform", n)
+        for n in range(MAX_TABLE_ROWS + 10)
     ]
-    channel = ET.fromstring(build(payload, {})).find("channel")
-    assert len(channel.findall("item")) == MAX_ITEMS
+    body = _channel(build(payload, {})).findall("item")[1].findtext("description")
+
+    # "<tr><td>" is a data row; the header row is "<tr><th>".
+    assert body.count("<tr><td>") == MAX_TABLE_ROWS
+    assert "more on the board" in body
 
 
-def test_a_prose_rule_gets_a_readable_title_not_a_slug():
-    """Some rules have no symbol -- the symbol is the sentence. Falling back
-    to the rule id gave titles like '2027.2: core-prose-sets-an-invalid...'."""
+def test_the_busiest_integrations_are_the_ones_listed(payload):
+    payload["integrations"] += [
+        _integration(f"x/repo{n}", f"d{n}", "2027.5", "legacy-device-tracker-platform", n)
+        for n in range(MAX_TABLE_ROWS + 10)
+    ]
+    body = _channel(build(payload, {})).findall("item")[1].findtext("description")
+
+    assert "x/repo29" in body      # most stars
+    assert "x/repo0" not in body   # fewest
+
+
+def test_the_feed_is_capped_by_release(payload):
+    payload["integrations"] = [
+        _integration(f"x/repo{n}", f"d{n}", f"20{27 + n}.5", "legacy-device-tracker-platform")
+        for n in range(MAX_ITEMS + 5)
+    ]
+    assert len(_channel(build(payload, {})).findall("item")) == MAX_ITEMS
+
+
+# --------------------------------------------------------------------------- #
+# rendering in a browser (#27)
+# --------------------------------------------------------------------------- #
+
+
+def test_the_feed_points_at_a_stylesheet_that_exists(payload, repo_root):
+    feed = build(payload, {})
+    assert f'<?xml-stylesheet type="text/xsl" href="{STYLESHEET}"?>' in feed
+    # A missing stylesheet renders as a blank page, which is worse than XML.
+    assert (repo_root / "docs" / STYLESHEET).is_file()
+
+
+def test_the_stylesheet_path_is_relative():
+    """Browsers refuse a cross-origin XSL, so this cannot become absolute."""
+    assert "://" not in STYLESHEET
+
+
+def test_the_stylesheet_is_well_formed(repo_root):
+    ET.parse(repo_root / "docs" / STYLESHEET)
+
+
+# --------------------------------------------------------------------------- #
+# escaping and labels
+# --------------------------------------------------------------------------- #
+
+
+def test_a_prose_rule_gets_a_readable_label_not_a_slug():
     rule = {
         "id": "core-prose-sets-an-invalid-entity-id-in-most-cases-entities",
         "breaks_in": "2027.2",
         "symbol": "sets an invalid entity ID: '{...}'. In most cases, entities "
-                  "should not set entity IDs themselves.",
+        "should not set entity IDs themselves.",
     }
-    title = title_for(rule)
-    assert title.startswith("2027.2: sets an invalid entity ID")
-    assert "core-prose" not in title
-    assert len(title) <= MAX_TITLE
-    # Cut on a word boundary, not mid-word.
-    assert not title.rstrip("…").endswith(" ")
-    assert title.endswith("…")
+    label = rule_label(rule)
+    assert label.startswith("sets an invalid entity ID")
+    assert "core-prose" not in label
+    assert len(label) <= MAX_LABEL
+    assert not label.rstrip("…").endswith(" ")
 
 
-def test_a_title_short_enough_is_left_alone():
-    assert title_for({"id": "x", "breaks_in": "2027.5", "symbol": "setup_scanner"}) == (
-        "2027.5: setup_scanner"
-    )
-
-
-def test_apostrophes_stay_readable(payload):
-    """html.escape turns every quote into &#x27;, which is valid but makes a
-    description unreadable in a reader that shows raw text."""
-    payload["rules"][0]["message"] = "doesn't specify unit_class when calling it"
-    feed = build(payload, {})
-    assert "doesn't specify" in feed
-    assert "&#x27;" not in feed
+def test_a_label_short_enough_is_left_alone():
+    assert rule_label({"id": "x", "symbol": "setup_scanner"}) == "setup_scanner"
 
 
 def test_markup_in_a_message_cannot_break_the_feed(payload):
     payload["rules"][0]["message"] = "uses <Thing> & </item> in a message"
     feed = build(payload, {})
-    ET.fromstring(feed)          # would raise if the escaping were wrong
-    assert "&lt;Thing&gt;" in feed and "&amp;" in feed
+    ET.fromstring(feed)  # would raise if the escaping were wrong
+    assert "&lt;Thing&gt;" in feed
+
+
+def test_a_cdata_terminator_in_content_cannot_break_the_feed(payload):
+    """Nothing escapes inside CDATA, so ']]>' has to be split by hand."""
+    payload["rules"][0]["message"] = "a message containing ]]> in the middle"
+    ET.fromstring(build(payload, {}))
+
+
+def test_grouping_counts_each_integration_once(payload):
+    payload["integrations"][0]["findings"].append(
+        {"rule_id": "legacy-device-tracker-platform", "breaks_in": "2027.5",
+         "file": "y.py", "line": 2}
+    )
+    rules, integrations = group_by_release(payload)["2027.5"]
+    assert len(integrations) == 2
+    assert len(rules) == 1
+
+
+def test_describe_reads_as_a_sentence_for_a_single_integration(payload):
+    payload["integrations"] = [payload["integrations"][2]]
+    rules, integrations = group_by_release(payload)["2026.10"]
+    body = describe("2026.10", rules, integrations)
+    assert "removes 1 API." in body
+    assert "1 HACS custom integration in the catalogue still uses it." in body
+
+
+def test_guid_changes_only_with_the_rule_set():
+    assert guid_for("2027.5", [{"id": "a"}]) == guid_for("2027.5", [{"id": "a"}])
+    assert guid_for("2027.5", [{"id": "a"}]) != guid_for("2027.5", [{"id": "b"}])
+    assert guid_for("2027.5", [{"id": "a"}]) != guid_for("2027.7", [{"id": "a"}])
+
+
+def test_backticks_in_a_message_become_code(payload):
+    """Rule messages are quoted prose that marks symbols with backticks, and a
+    reader shows those literally unless they are turned into markup."""
+    payload["rules"][0]["message"] = "passes `hass` to `async_extract_entities`"
+    body = _channel(build(payload, {})).findall("item")[1].findtext("description")
+    assert "<code>hass</code>" in body
+    assert "`hass`" not in body
+
+
+def test_a_message_that_does_not_end_in_a_stop_gets_one(payload):
+    """Otherwise it runs straight into the sentence that follows it."""
+    payload["rules"][0]["message"] = "doesn't specify unit_class when calling it"
+    body = _channel(build(payload, {})).findall("item")[1].findtext("description")
+    assert "calling it. Used by 11 integrations." in body
+
+
+def test_an_uncapped_item_gets_one_board_link_not_two(payload):
+    """A full table used to be followed by both "and N more" and a second
+    "full list" link, pointing at the same anchor."""
+    body = _channel(build(payload, {})).findall("item")[1].findtext("description")
+    assert body.count("#release-2027.5") == 1
+    assert "more on the board" not in body

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,7 +63,13 @@ def test_pages_root_holds_only_published_artifacts(repo_root):
     means a stray file can never shadow the board or the index.
     """
     published = sorted(p.name for p in (repo_root / "docs").iterdir())
-    assert published == [".nojekyll", "feed.xml", "index.html", "index.json"], published
+    assert published == [
+        ".nojekyll",
+        "feed.xml",
+        "feed.xsl",
+        "index.html",
+        "index.json",
+    ], published
 
 
 def test_the_crawl_commits_every_published_artifact(repo_root):

--- a/tools/build_index.py
+++ b/tools/build_index.py
@@ -433,7 +433,7 @@ def render_html(payload: dict[str, Any]) -> str:
             )
 
         sections.append(
-            f'<section class="release">'
+            f'<section class="release" id="release-{html.escape(release)}">'
             f"<h2>Home Assistant {html.escape(release)}"
             f'<span class="pill">{len(entries)} integrations</span></h2>'
             f'<ul class="rulelist">{rule_items}</ul>'

--- a/tools/feed.py
+++ b/tools/feed.py
@@ -5,13 +5,23 @@ crawl." The index is a snapshot, so following it means diffing it yourself.
 The feed answers the other question, which is what is *new*, and it costs
 nothing to host because the crawl already publishes static files.
 
-One item per rule, dated the first time the crawl published it. That date is
-kept in ``state/feed.json``, because a rule carries the release it breaks in,
-not the day it was announced.
+One item per Home Assistant release, carrying that release's own content: what
+it removes, and which HACS integrations still use it. A release is the unit
+people follow, and it gives a reader something to read in place.
+
+An item is news when a rule joins the release. The integration count moves
+every day as the crawl widens, and dating the item on that would re-notify
+every subscriber daily, so ``pubDate`` is the newest first-seen date among the
+release's rules. Those dates live in ``state/feed.json``, keyed by rule,
+because a rule carries the release it breaks in and not the day it was
+announced.
 """
 
 from __future__ import annotations
 
+import hashlib
+import html
+import re
 from datetime import UTC, datetime
 from typing import Any
 from xml.sax.saxutils import escape
@@ -21,8 +31,22 @@ from tools.rules_engine import parse_version
 BOARD = "https://booyaka101.github.io/hass-breakage-radar/"
 FEED_URL = f"{BOARD}feed.xml"
 
-#: Enough for a reader that has been away for months, without shipping the lot.
-MAX_ITEMS = 60
+#: Sits next to feed.xml in docs/. Stays relative: browsers refuse a
+#: cross-origin XSL, so an absolute URL would silently stop it rendering.
+STYLESHEET = "feed.xsl"
+
+#: Releases kept in the feed. Deadlines are announced about a year ahead, so
+#: this is years of history rather than the handful that are live.
+MAX_ITEMS = 12
+
+#: Integrations listed inside one item. The whole table for the biggest release
+#: is over 370 KB of markup, which is not something to put in a file every
+#: subscriber refetches; the rest are one click away on the board.
+MAX_TABLE_ROWS = 20
+
+#: Long enough for a symbol, short enough to read in a list. Prose rules carry
+#: a sentence where the others carry a name.
+MAX_LABEL = 72
 
 
 def _rfc822(value: str) -> str:
@@ -36,6 +60,26 @@ def _rfc822(value: str) -> str:
     return moment.strftime("%a, %d %b %Y %H:%M:%S +0000")
 
 
+def _cdata(markup: str) -> str:
+    """Wrap generated HTML so readers get markup rather than escaped text."""
+    return "<![CDATA[" + markup.replace("]]>", "]]]]><![CDATA[>") + "]]>"
+
+
+def plural(count: int, singular: str, plural_form: str | None = None) -> str:
+    """``1 integration`` / ``9 integrations``, since a sentence cannot say (s).
+
+    Same helper as the integration's repairs.py. Not imported from there:
+    tools/ and custom_components/ stay separable, which is why the engine is
+    vendored rather than shared.
+    """
+    return singular if count == 1 else (plural_form or f"{singular}s")
+
+
+def anchor_for(release: str) -> str:
+    """The board section this release renders into."""
+    return f"{BOARD}#release-{release}"
+
+
 def update_first_seen(
     rules: list[dict[str, Any]], seen: dict[str, str], *, now: str
 ) -> dict[str, str]:
@@ -45,55 +89,187 @@ def update_first_seen(
     return seen
 
 
-#: Long enough for the deadline plus a symbol, short enough for a reader's
-#: item list without the title being cut off mid-word.
-MAX_TITLE = 72
+def rule_label(rule: dict[str, Any]) -> str:
+    """The symbol a rule is about, or a trimmed sentence for prose rules.
 
-
-def title_for(rule: dict[str, Any]) -> str:
-    """``2027.5: setup_scanner``, or a trimmed sentence for prose rules.
-
-    Most rules name a symbol. ``kind: prose`` rules do not have one -- the
-    symbol is the sentence -- so they get the sentence, cut on a word boundary
-    rather than showing a dangling ``'{...}'`` placeholder.
+    ``kind: prose`` rules have no symbol -- the symbol is the sentence -- so
+    they get the sentence cut on a word boundary rather than a dangling
+    ``'{...}'`` placeholder or the rule's slug.
     """
     symbol = " ".join((rule.get("symbol") or "").split())
     name = symbol or rule["id"]
-    prefix = f"{rule['breaks_in']}: "
-    room = MAX_TITLE - len(prefix)
-    if len(name) > room:
-        name = name[: room - 1].rsplit(" ", 1)[0].rstrip(" ,.;:") + "…"
-    return prefix + name
+    if len(name) > MAX_LABEL:
+        name = name[: MAX_LABEL - 1].rsplit(" ", 1)[0].rstrip(" ,.;:") + "…"
+    return name
 
 
-def describe(rule: dict[str, Any], repos_hit: int) -> str:
-    parts = [rule.get("message", "").strip()]
-    if repos_hit:
-        parts.append(
-            f"{repos_hit} integration(s) in the HACS catalogue currently use it."
+def title_for(release: str) -> str:
+    """What the board's own heading says, so the two read as one thing.
+
+    Deliberately carries no count: that changes daily, and a title that moves
+    makes an unchanged item look new in some readers.
+    """
+    return f"Home Assistant {release}"
+
+
+def guid_for(release: str, rules: list[dict[str, Any]]) -> str:
+    """Stable per release, until its rule set changes.
+
+    Folding the rules in is what surfaces a newly announced removal. Readers
+    key off the guid, so a fixed one would leave the item sitting unread at its
+    original date however much was added to it.
+    """
+    digest = hashlib.sha256(
+        "\n".join(sorted(rule["id"] for rule in rules)).encode("utf-8")
+    ).hexdigest()[:8]
+    return f"breakage-radar:release:{release}:{digest}"
+
+
+def published_for(
+    rules: list[dict[str, Any]], seen: dict[str, str], generated: str
+) -> str:
+    """Newest first-seen date among the release's rules.
+
+    So an item resurfaces when a removal is announced for that release, and
+    stays put when the crawl merely finds more integrations using one.
+    """
+    return max((seen.get(rule["id"], generated) for rule in rules), default=generated)
+
+
+def _message_html(message: str) -> str:
+    """Rule messages are quoted from prose that marks symbols with backticks."""
+    text = html.escape(message.strip())
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    # Messages are sentences from a blog post or from core, and not all of them
+    # were written to be followed by another one.
+    if text and text[-1] not in ".!?":
+        text += "."
+    return text
+
+
+def _rule_list(rules: list[dict[str, Any]]) -> str:
+    items = []
+    for rule in rules:
+        label = html.escape(rule_label(rule))
+        message = _message_html(rule.get("message") or "")
+        source = rule.get("source_url") or rule.get("source") or ""
+        # A rule's source can be a bare "file.py:418", which is not a link.
+        if str(source).startswith("http"):
+            where = f' <a href="{html.escape(source)}">source</a>'
+        elif source:
+            where = f" <code>{html.escape(str(source))}</code>"
+        else:
+            where = ""
+        hit = rule.get("repos_hit") or 0
+        used = f" Used by {hit} {plural(hit, 'integration')}." if hit else ""
+        items.append(f"<li><strong>{label}</strong>: {message}{used}{where}</li>")
+    return "<ul>" + "".join(items) + "</ul>"
+
+
+def _table(integrations: list[dict[str, Any]], release: str) -> str:
+    ranked = sorted(
+        integrations,
+        key=lambda entry: (-(entry.get("stargazers_count") or 0), entry["full_name"]),
+    )
+    rows = []
+    for entry in ranked[:MAX_TABLE_ROWS]:
+        hits = [f for f in entry["findings"] if f["breaks_in"] == release]
+        rows.append(
+            "<tr>"
+            f'<td><a href="{html.escape(entry["repo_url"])}">'
+            f"{html.escape(entry['full_name'])}</a></td>"
+            f"<td>{html.escape(entry['domain'])}</td>"
+            f"<td>{html.escape(entry['version'])}</td>"
+            f"<td>{entry.get('stargazers_count') or 0}</td>"
+            f"<td>{len(hits)}</td>"
+            "</tr>"
         )
-    if rule.get("replacement"):
-        parts.append(f"Replacement: {rule['replacement']}.")
-    parts.append(f"Confidence: {rule.get('confidence', 'medium')}.")
-    return " ".join(p for p in parts if p)
+    table = (
+        "<table><thead><tr><th>Repository</th><th>Domain</th><th>Version</th>"
+        "<th>Stars</th><th>Findings</th></tr></thead>"
+        "<tbody>" + "".join(rows) + "</tbody></table>"
+    )
+    rest = len(ranked) - MAX_TABLE_ROWS
+    link = f"and {rest} more on the board" if rest > 0 else "See it on the board"
+    return table + f'<p><a href="{anchor_for(release)}">{link}</a></p>'
+
+
+def describe(
+    release: str, rules: list[dict[str, Any]], integrations: list[dict[str, Any]]
+) -> str:
+    """The item body: what this release removes, and who still uses it."""
+    count = len(integrations)
+    lead = (
+        f"<p>Home Assistant {html.escape(release)} removes "
+        f"{len(rules)} {plural(len(rules), 'API')}. "
+        f"{count} HACS custom {plural(count, 'integration')} in the catalogue "
+        f"still {plural(count, 'uses', 'use')} "
+        f"{plural(len(rules), 'it', 'them')}.</p>"
+    )
+    heading = (
+        # Ranked by stars, so say stars: "most used" would be a claim the
+        # crawl cannot make.
+        f"<h3>Most starred of the {count} affected</h3>"
+        if count > MAX_TABLE_ROWS
+        else "<h3>Affected integrations</h3>"
+    )
+    return (
+        lead
+        + "<h3>What is being removed</h3>"
+        + _rule_list(rules)
+        + heading
+        + _table(integrations, release)
+    )
+
+
+def group_by_release(
+    payload: dict[str, Any],
+) -> dict[str, tuple[list[dict[str, Any]], list[dict[str, Any]]]]:
+    """``release -> (rules, integrations)`` for every release with a finding."""
+    rules_by_id = {rule["id"]: rule for rule in payload.get("rules", [])}
+    # Keyed by id rather than searched with ``in``: the biggest release holds
+    # 554 integrations, and ``in`` on a list of dicts compares every field of
+    # every one of them.
+    rules: dict[str, dict[str, dict[str, Any]]] = {}
+    entries: dict[str, dict[str, dict[str, Any]]] = {}
+    for integration in payload.get("integrations", []):
+        for finding in integration.get("findings", []):
+            release = finding["breaks_in"]
+            rules.setdefault(release, {})
+            entries.setdefault(release, {})[integration["full_name"]] = integration
+            rule = rules_by_id.get(finding["rule_id"])
+            if rule is not None:
+                rules[release][rule["id"]] = rule
+
+    grouped = {}
+    for release, by_name in entries.items():
+        by_id = rules[release]
+        grouped[release] = (
+            [by_id[rule_id] for rule_id in sorted(by_id)],
+            list(by_name.values()),
+        )
+    return grouped
 
 
 def build(payload: dict[str, Any], seen: dict[str, str]) -> str:
     """Render the feed for a built index payload."""
     generated = payload.get("generated_utc", "")
-    items = sorted(
-        payload.get("rules", []),
-        key=lambda r: (
-            seen.get(r["id"], generated),
-            # Newest first, and on the first run every rule shares a date, so
-            # fall back to the soonest deadline rather than an arbitrary id.
-            [-part for part in parse_version(r["breaks_in"])],
+    grouped = group_by_release(payload)
+    releases = sorted(
+        grouped,
+        key=lambda release: (
+            published_for(grouped[release][0], seen, generated),
+            # Every rule shares a date on the first run, so fall back to the
+            # soonest deadline rather than an arbitrary string sort.
+            [-part for part in parse_version(release)],
         ),
         reverse=True,
     )[:MAX_ITEMS]
 
     lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',
+        # Readers ignore this; it is what stops a browser showing raw XML.
+        f'<?xml-stylesheet type="text/xsl" href="{STYLESHEET}"?>',
         '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
         "  <channel>",
         "    <title>Breakage Radar: Home Assistant API removals</title>",
@@ -104,20 +280,16 @@ def build(payload: dict[str, Any], seen: dict[str, str]) -> str:
         f"    <lastBuildDate>{_rfc822(generated)}</lastBuildDate>",
         f'    <atom:link href="{FEED_URL}" rel="self" type="application/rss+xml"/>',
     ]
-    for rule in items:
-        published = seen.get(rule["id"], generated)
-        title = title_for(rule)
-        link = rule.get("source_url") or rule.get("source") or BOARD
-        if not str(link).startswith("http"):
-            link = BOARD
+    for release in releases:
+        rules, integrations = grouped[release]
         lines += [
             "    <item>",
-            f"      <title>{escape(title)}</title>",
-            f"      <link>{escape(link)}</link>",
-            f'      <guid isPermaLink="false">breakage-radar:{escape(rule["id"])}</guid>',
-            f"      <pubDate>{_rfc822(published)}</pubDate>",
-            f"      <category>{escape(rule['breaks_in'])}</category>",
-            f"      <description>{escape(describe(rule, rule.get('repos_hit', 0)))}</description>",
+            f"      <title>{escape(title_for(release))}</title>",
+            f"      <link>{escape(anchor_for(release))}</link>",
+            f'      <guid isPermaLink="false">{escape(guid_for(release, rules))}</guid>',
+            f"      <pubDate>{_rfc822(published_for(rules, seen, generated))}</pubDate>",
+            f"      <category>{escape(release)}</category>",
+            f"      <description>{_cdata(describe(release, rules, integrations))}</description>",
             "    </item>",
         ]
     lines += ["  </channel>", "</rss>", ""]


### PR DESCRIPTION
## What this changes

Closes #28 and #27, which are the two halves of making the feed worth subscribing to.

**Each item is a release, not a rule.** The feed published one item per rule, titled `2027.8: <symbol>`, described in a sentence, linking to a line in home-assistant/core. A reader showed sixty bookmarks. An item now carries the release: the board's own `h2` as the title, its rule list and its table of affected integrations as the body, and a link to that release's section of the board. `build_index.py` gained `id="release-<version>"` on each section for those links to land on.

**A stylesheet, so a browser stops showing raw XML.** Chrome never rendered feeds and Firefox dropped its reader in 64, so `feed.xml` looked broken to anyone who clicked rather than subscribed. `docs/feed.xsl` renders it as a page that says what a feed is and where to paste the URL. Readers ignore it, so the XML contract is unchanged.

Two things the obvious version gets wrong, both raised in #28:

* **Size.** Embedding the board's sections verbatim measures 475 KB against the old 31 KB feed, four fifths of that 2027.8 alone at 555 rows, and it grows with every crawl. The body carries the rule list in full, which is the actual news and is small, plus the twenty most starred integrations and a count of the rest. The feed ends up at 27,925 bytes over 5 items, down from 31,867 over 60.
* **What counts as new.** A release section changes daily as the crawl widens. Dating items on that would re-notify every subscriber five times a day, which is what `state/feed.json` exists to prevent. `pubDate` is the newest first-seen date among the release's rules, so a newly announced removal resurfaces the item and a rising integration count does not.

Two deliberate departures from the issue text:

* `state/feed.json` is **not** rekeyed from rules to releases. It stays rule-keyed and the release date is derived from it, so nothing migrates and no existing subscriber sees their items vanish and reappear.
* The guid is `breakage-radar:release:<release>:<hash of rule ids>` rather than just the release. Readers key off the guid, so a fixed one would leave an item sitting at its original date however much was added to it, and the pubDate rule above would never reach anybody.

`docs/feed.xml` and `docs/index.html` are deliberately not regenerated here. The daily crawl rebuilds both, and committing generated output puts the branch in conflict with the crawl bot, which is the trap #18 documented. The live feed keeps its current format until the next run.

## How you verified it

* `python -m pytest` passes: 265 passed, 3 skipped, up from 262 on main.
* `tests/test_feed.py` rewritten for the new model, 27 cases covering the item shape, the pubDate and guid rules, the size cap, the CDATA escaping and the stylesheet wiring.
* Built the board and feed from the live index and rendered `feed.xml` in Chrome, checking it reads as a page rather than XML and that the release anchors resolve.
* Two rounds of review after that first render. The first fixed a duplicated release pill, backticks showing literally instead of as code, messages running into the next sentence without a full stop, `API(s)`-style pluralisation, two adjacent links to the same anchor, a "most used" heading for a list ranked by stars, and an O(n squared) `in` over a list of 554 dicts in `group_by_release`. The second replaced the `&mdash;` separator with a colon per the house style, reused the existing `plural()` shape from `repairs.py` instead of four stacked ternaries, unpicked a dense dict comprehension, dropped a redundant parameter and a no-op `escape()`, and corrected a module docstring that claimed the feed knows what is installed anywhere.
* `ruff check` clean on every file touched. One pre-existing `I001` in `tests/test_integration.py` is on main already and left alone.
* An existing guard caught something worth noting: `test_the_crawl_commits_every_published_artifact` failed because `docs/feed.xsl` is a new Pages artifact the crawl never staged. Added to the workflow's `git add`.

## Checklist

- [x] `python -m pytest` passes
- [x] Added or updated a test for this change
- [x] Updated `README.md` if behaviour changed
- [x] Added a `CHANGELOG.md` entry under "Unreleased"
- [x] No credentials, tokens or personal data in the diff or in pasted output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
