### PR TITLE
chore: release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
-## Unreleased
+## 1.6.1 — 2026-08-19
 
 ### The feed carries releases instead of bookmarks
 

--- a/custom_components/breakage_radar/manifest.json
+++ b/custom_components/breakage_radar/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/Booyaka101/hass-breakage-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-breakage-radar"
-version = "1.6.0"
+version = "1.6.1"
 description = "Find out which of your Home Assistant custom integrations stop working, and in which future release."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Version bump and changelog date for the feed rework (#29, closing #28 and #27).

Patch rather than minor: the Home Assistant integration is byte-for-byte unchanged, so there is nothing for a user to update to. What changed is the published feed. Same reasoning as 1.4.1, which added the feed in the first place.

`manifest.json` and `pyproject.toml` both go to 1.6.1, which `test_integration.py` enforces agreement on.

## How you verified it

* `python -m pytest` passes: 265 passed, 3 skipped.
* The feed itself was rendered and reviewed on #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)