### PR TITLE
Rate DeviceRegistry.async_get_device high, and make re-ratings publishable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
+## Unreleased
+
+### `DeviceRegistry.async_get_device` is rated high confidence
+
+That rule is the single biggest in the set, 609 findings across 340
+repositories, 36% of everything the crawl reports. It shipped at medium, which
+means the board's "High only" filter hid all of it.
+
+Checked before changing it: 197 findings across 100 of those repositories were
+verified against the source at the tag that was scanned. All 197 are genuine,
+none is a false positive. That sits on top of the 1.3.1 pass, which
+hand-checked 45 findings, fixed the one error class with `not_awaited` and
+re-scanned 36 repositories at zero. With no failures in 197, the upper bound
+on the false positive rate is about 1.5%.
+
+Considered and rejected: rewriting the matcher to prove the receiver is a
+`DeviceRegistry`, the way `attr_access_typed` does for `DeviceEntry`. The rule
+is already accurate, so that would have cost recall for nothing. It would also
+have needed a new matcher type, and an install running an older engine skips
+an unknown type, which for a rule that currently matches means a local scan
+reporting clean over an index finding. Widening a rule can afford a new
+matcher type; narrowing one cannot.
+
+The board now takes each finding's confidence from the rule rather than from
+the crawl record. `rules_hash` deliberately ignores confidence, so a re-rating
+never invalidates a cached scan and would otherwise have sat unpublished until
+each repository happened to be scanned again. Verified as a no-op on the
+current crawl: all 1 695 findings already agree with their rule.
+
 ## 1.6.1 — 2026-08-19
 
 ### The feed carries releases instead of bookmarks

--- a/data/manual_rules.json
+++ b/data/manual_rules.json
@@ -162,7 +162,7 @@
       "breaks_in": "2027.8",
       "source": "https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry",
       "origin": "manual",
-      "confidence": "medium",
+      "confidence": "high",
       "replacement": "async_get_device_by_identifier() / async_get_device_by_connection()",
       "match": {
         "type": "call",

--- a/tests/test_build_index.py
+++ b/tests/test_build_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 
 import pytest
@@ -230,3 +231,26 @@ def test_coverage_never_claims_more_scanned_than_the_catalogue_holds():
     assert coverage["repos_scanned"] == 1
     assert coverage["repos_delisted"] == 1
     assert coverage["repos_scanned"] <= coverage["catalog_total"]
+
+
+def test_confidence_comes_from_the_rule_not_the_crawl_record():
+    """A re-rating has to reach the board without a full rescan.
+
+    ``rules_hash`` deliberately ignores confidence, so raising or lowering a
+    rule's rating never invalidates a cached scan and the stored findings keep
+    whatever they were rated when that repository was last visited.
+    """
+    rules = copy.deepcopy(RULES_DOC)
+    findings = copy.deepcopy(FINDINGS_DOC)
+    findings["repos"]["example/affected"]["findings"][0]["confidence"] = "medium"
+
+    payload = build_payload(rules, findings, CATALOG_DOC)
+    assert payload["integrations"][0]["findings"][0]["confidence"] == "high"
+
+
+def test_a_finding_whose_rule_vanished_keeps_its_own_confidence():
+    rules = copy.deepcopy(RULES_DOC)
+    rules["rules"] = [r for r in rules["rules"] if r["id"] != "legacy-device-tracker-platform"]
+    payload = build_payload(rules, copy.deepcopy(FINDINGS_DOC), CATALOG_DOC)
+
+    assert payload["integrations"][0]["findings"][0]["confidence"] == "high"

--- a/tools/build_index.py
+++ b/tools/build_index.py
@@ -106,6 +106,16 @@ def build_payload(
         if isinstance(entry, dict)
     }
 
+    # Confidence is a property of the rule, not of the hit. A crawl record
+    # keeps whatever it was rated when that repository was last scanned, and
+    # rules_hash deliberately ignores confidence, so a re-rating never triggers
+    # a rescan. Read it from the rule and it applies on the next build.
+    confidence_by_rule = {
+        rule["id"]: rule["confidence"]
+        for rule in rules_doc.get("rules", [])
+        if rule.get("confidence")
+    }
+
     repos: dict[str, Any] = findings_doc.get("repos", {})
     integrations: list[dict[str, Any]] = []
     clean_domains: list[str] = []
@@ -119,6 +129,11 @@ def build_payload(
         domain = record.get("domain") or catalog_entry.get("domain") or ""
         findings = [
             {key: finding[key] for key in REQUIRED_FINDING_KEYS}
+            | {
+                "confidence": confidence_by_rule.get(
+                    finding["rule_id"], finding["confidence"]
+                )
+            }
             for finding in record.get("findings", [])
         ]
 


### PR DESCRIPTION
## What this changes

`device-registry-async-get-device` moves from `medium` to `high`. It is the biggest rule in the set, 609 findings across 340 repositories, 36% of everything the crawl reports, and at medium the board's "High only" filter hid all of it.

Two things had to be true for that to be the right change, and both were checked rather than assumed.

**The rule is accurate.** 197 findings across 100 of the 340 repositories were verified against the source at the tag that was scanned: 197 genuine, 0 false positives. That is on top of the 1.3.1 pass, which hand-checked 45 findings, fixed the one error class with `not_awaited`, then re-scanned 36 repositories at zero. With no failures in 197 the 95% upper bound on the false positive rate is about 1.5%.

**The rating had to be able to reach anyone.** It could not: `build_index` copied `confidence` out of the crawl record, and `rules_hash` deliberately excludes confidence so a re-rating never invalidates a cached scan. The rating would have sat unpublished until each repository happened to be rescanned. Confidence now comes from the rule. Verified as a no-op on the current crawl, where all 1 695 findings already agree with their rule, so nothing except this rule moves.

**Rejected, and worth recording:** rewriting the matcher to prove the receiver is a `DeviceRegistry`, which is what #22 proposed in my own words. The rule is already accurate, so a receiver proof trades recall for nothing, and it would need a new matcher type. An install on an older engine skips an unknown type, and for a rule that currently matches that means its local scan reports `clean` and beats the index finding. Widening a rule can afford a new matcher type. Narrowing one cannot.

Nothing in the integration branches on confidence, so no behaviour changes on anyone's box and no release is needed. The board picks this up on the next crawl.

## How you verified it

* `python -m pytest` passes: 267 passed, 3 skipped, up from 265.
* Two new tests: confidence is taken from the rule rather than the crawl record, and a finding whose rule has vanished keeps its own.
* Sampled 100 of 340 repositories, every hit in each, 197 findings, against live source at the scanned tags. Seven needed hand-checking and all seven are genuine; six of those only failed automatic checking because they use Python 3.14 syntax my 3.12 could not parse.
* Measured the `build_index` change against the real crawl before trusting it: 1 695 findings compared, 0 would change.
* `ruff check` clean on the files touched.

## Checklist

- [x] `python -m pytest` passes
- [x] Added or updated a test for this change
- [ ] Updated `README.md` if behaviour changed
- [x] Added a `CHANGELOG.md` entry under "Unreleased"
- [x] No credentials, tokens or personal data in the diff or in pasted output

🤖 Generated with [Claude Code](https://claude.com/claude-code)