### PR TITLE
Deduplicate the card and integration scan paths

### DIFF
--- a/custom_components/breakage_radar/scanner.py
+++ b/custom_components/breakage_radar/scanner.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from collections.abc import Callable, Iterator
 from typing import Any
 
 from .discovery import IGNORED_DIRECTORIES, _manifest_domain
@@ -45,9 +46,9 @@ def _rules_fingerprint(rules_payload: list[dict[str, Any]], current_version: str
     return digest.hexdigest()[:16]
 
 
-def _domain_python_files(domain_dir: str) -> tuple[list[tuple[str, str]], int]:
-    """Every ``*.py`` as ``(absolute, relative)``, plus a count of directories
-    the walk could not enter.
+def _walk(directory: str, wanted: Callable[[str], bool]) -> tuple[list[tuple[str, str]], int]:
+    """Every file ``wanted`` accepts, as ``(absolute, relative)``, plus a count
+    of directories the walk could not enter.
 
     Symlinked subdirectories are skipped so a link pointing back up the tree
     cannot loop the scan.
@@ -60,7 +61,7 @@ def _domain_python_files(domain_dir: str) -> tuple[list[tuple[str, str]], int]:
         unreadable_dirs += 1
 
     for root, dirnames, filenames in os.walk(
-        domain_dir, onerror=_on_error, followlinks=False
+        directory, onerror=_on_error, followlinks=False
     ):
         dirnames[:] = sorted(
             d
@@ -69,15 +70,101 @@ def _domain_python_files(domain_dir: str) -> tuple[list[tuple[str, str]], int]:
             and not d.startswith(".")
             and not os.path.islink(os.path.join(root, d))
         )
-        relative_root = os.path.relpath(root, domain_dir)
+        relative_root = os.path.relpath(root, directory)
         for name in sorted(filenames):
-            if not name.endswith(".py"):
+            if not wanted(name):
                 continue
             relative = name if relative_root == "." else os.path.join(relative_root, name)
             files.append(
                 (os.path.join(root, name), relative.replace(os.sep, "/"))
             )
     return files, unreadable_dirs
+
+
+def _is_python(name: str) -> bool:
+    return name.endswith(".py")
+
+
+def _is_card_source(name: str) -> bool:
+    # A .d.ts declares the API rather than calling it, so it can only produce
+    # a finding nobody can act on.
+    return name.endswith(JS_SUFFIXES) and not name.endswith(".d.ts")
+
+
+def _signature(
+    files: list[tuple[str, str]],
+    unreadable_dirs: int,
+    fingerprint: str,
+    max_files: int,
+    max_bytes: int,
+) -> tuple[Any, ...]:
+    """What a cached result stays valid for: the same files, rules and caps."""
+    newest_mtime = 0
+    total_size = 0
+    for absolute, _relative in files:
+        try:
+            stat = os.stat(absolute)
+        except OSError:
+            continue
+        newest_mtime = max(newest_mtime, stat.st_mtime_ns)
+        total_size += stat.st_size
+    return (
+        len(files),
+        newest_mtime,
+        total_size,
+        unreadable_dirs,
+        fingerprint,
+        max_files,
+        max_bytes,
+    )
+
+
+def _cached(
+    cache: dict[str, tuple[tuple[Any, ...], dict[str, Any]]] | None,
+    key: str,
+    signature: tuple[Any, ...],
+    compute: Callable[[], dict[str, Any]],
+) -> tuple[dict[str, Any], bool]:
+    """Reuse the stored result while its signature holds, else compute one."""
+    if cache is not None and key in cache and cache[key][0] == signature:
+        result = dict(cache[key][1])
+        result["cached"] = True
+        return result, True
+    result = compute()
+    if cache is not None:
+        cache[key] = (signature, dict(result))
+    return result, False
+
+
+def _read_files(
+    files: list[tuple[str, str]],
+    *,
+    max_files: int,
+    max_bytes: int,
+    counts: dict[str, int],
+) -> Iterator[tuple[str, bytes]]:
+    """Yield ``(relative, raw bytes)`` for every file inside the caps.
+
+    Whatever it refuses is counted in ``counts``: anything past the caps under
+    ``skipped_files``, anything the OS would not hand over under ``unreadable``.
+    A truncated scan is never allowed to read as a clean one, so the caller
+    turns those counts into a verdict.
+    """
+    for position, (absolute, relative) in enumerate(files):
+        if position >= max_files:
+            counts["skipped_files"] += len(files) - position
+            return
+        try:
+            if os.path.getsize(absolute) > max_bytes:
+                counts["skipped_files"] += 1
+                continue
+            with open(absolute, "rb") as handle:
+                raw = handle.read()
+        except OSError:
+            counts["unreadable"] += 1
+            continue
+        # Outside the try: an OSError raised downstream is not a read failure.
+        yield relative, raw
 
 
 def _scan_domain(
@@ -96,28 +183,18 @@ def _scan_domain(
     """
     stats = ScanStats()
     findings: list[dict[str, Any]] = []
-    unreadable_files = 0
-    skipped_files = 0
+    counts = {"skipped_files": 0, "unreadable": 0}
 
-    for position, (absolute, relative) in enumerate(files):
-        if position >= max_files:
-            skipped_files += len(files) - position
-            break
+    for relative, source in _read_files(
+        files, max_files=max_files, max_bytes=max_bytes, counts=counts
+    ):
         scan_path = f"custom_components/{directory_name}/{relative}"
-        try:
-            if os.path.getsize(absolute) > max_bytes:
-                skipped_files += 1
-                continue
-            with open(absolute, "rb") as handle:
-                source = handle.read()
-        except OSError:
-            unreadable_files += 1
-            continue
         findings.extend(
             finding.to_dict() for finding in match_source(scan_path, source, rules, stats)
         )
 
-    unparsed = len(stats.syntax_errors) + unreadable_files
+    skipped_files = counts["skipped_files"]
+    unparsed = len(stats.syntax_errors) + counts["unreadable"]
     reason = ""
     if findings:
         status = "affected"
@@ -199,42 +276,21 @@ def scan_installed(
             continue
 
         domain = _manifest_domain(entry.path, entry.name)
-        files, unreadable_dirs = _domain_python_files(entry.path)
-
-        newest_mtime = 0
-        total_size = 0
-        for absolute, _relative in files:
-            try:
-                stat = os.stat(absolute)
-            except OSError:
-                continue
-            newest_mtime = max(newest_mtime, stat.st_mtime_ns)
-            total_size += stat.st_size
-        signature = (
-            len(files),
-            newest_mtime,
-            total_size,
-            unreadable_dirs,
-            fingerprint,
-            max_files,
-            max_bytes,
-        )
-
-        if cache is not None and domain in cache and cache[domain][0] == signature:
-            result = dict(cache[domain][1])
-            result["cached"] = True
-            cached_domains += 1
-        else:
-            result = _scan_domain(
+        files, unreadable_dirs = _walk(entry.path, _is_python)
+        result, was_cached = _cached(
+            cache,
+            domain,
+            _signature(files, unreadable_dirs, fingerprint, max_files, max_bytes),
+            lambda: _scan_domain(
                 entry.name,
                 files,
                 unreadable_dirs,
                 rules,
                 max_files=max_files,
                 max_bytes=max_bytes,
-            )
-            if cache is not None:
-                cache[domain] = (signature, dict(result))
+            ),
+        )
+        cached_domains += was_cached
 
         domains[domain] = result
         totals["files_scanned"] += result["files_scanned"]
@@ -251,37 +307,6 @@ def scan_installed(
         "rules_fingerprint": fingerprint,
         "engine_version": ENGINE_VERSION,
     }
-
-
-def _card_js_files(card_dir: str) -> tuple[list[tuple[str, str]], int]:
-    """Every ``.js``/``.ts``/``.mjs`` under one installed card, ``.d.ts`` and
-    vendored directories excluded, plus a count of unreadable directories."""
-    files: list[tuple[str, str]] = []
-    unreadable_dirs = 0
-
-    def _on_error(_err: OSError) -> None:
-        nonlocal unreadable_dirs
-        unreadable_dirs += 1
-
-    for root, dirnames, filenames in os.walk(
-        card_dir, onerror=_on_error, followlinks=False
-    ):
-        dirnames[:] = sorted(
-            d
-            for d in dirnames
-            if d not in UNSCANNED_DIRECTORIES
-            and not d.startswith(".")
-            and not os.path.islink(os.path.join(root, d))
-        )
-        relative_root = os.path.relpath(root, card_dir)
-        for name in sorted(filenames):
-            if not name.endswith(JS_SUFFIXES) or name.endswith(".d.ts"):
-                continue
-            relative = name if relative_root == "." else os.path.join(relative_root, name)
-            files.append(
-                (os.path.join(root, name), relative.replace(os.sep, "/"))
-            )
-    return files, unreadable_dirs
 
 
 def _scan_card(
@@ -302,31 +327,22 @@ def _scan_card(
     """
     stats = ScanStats()
     findings: list[Any] = []
-    unreadable_files = 0
-    skipped_files = 0
+    counts = {"skipped_files": 0, "unreadable": 0}
     skipped_minified = 0
 
-    for position, (absolute, relative) in enumerate(files):
-        if position >= max_files:
-            skipped_files += len(files) - position
-            break
+    for relative, raw in _read_files(
+        files, max_files=max_files, max_bytes=max_bytes, counts=counts
+    ):
         scan_path = f"www/community/{card_name}/{relative}"
-        try:
-            if os.path.getsize(absolute) > max_bytes:
-                skipped_files += 1
-                continue
-            with open(absolute, "rb") as handle:
-                text = handle.read().decode("utf-8", "replace")
-        except OSError:
-            unreadable_files += 1
-            continue
+        text = raw.decode("utf-8", "replace")
         if looks_minified_js(scan_path, text):
             skipped_minified += 1
             continue
         findings.extend(match_js_source(scan_path, text, rules, stats))
 
     findings = [finding.to_dict() for finding in dedupe_js_findings(findings)]
-    unparsed = len(stats.syntax_errors) + unreadable_files
+    skipped_files = counts["skipped_files"]
+    unparsed = len(stats.syntax_errors) + counts["unreadable"]
     reason = ""
     if findings:
         status = "affected"
@@ -400,42 +416,23 @@ def scan_cards(
         except OSError:
             continue
 
-        files, unreadable_dirs = _card_js_files(entry.path)
-        newest_mtime = 0
-        total_size = 0
-        for absolute, _relative in files:
-            try:
-                stat = os.stat(absolute)
-            except OSError:
-                continue
-            newest_mtime = max(newest_mtime, stat.st_mtime_ns)
-            total_size += stat.st_size
-        signature = (
-            len(files),
-            newest_mtime,
-            total_size,
-            unreadable_dirs,
-            fingerprint,
-            max_files,
-            max_bytes,
-        )
-
-        cache_key = f"card:{entry.name}"
-        if cache is not None and cache_key in cache and cache[cache_key][0] == signature:
-            result = dict(cache[cache_key][1])
-            result["cached"] = True
-            cached_cards += 1
-        else:
-            result = _scan_card(
+        files, unreadable_dirs = _walk(entry.path, _is_card_source)
+        result, was_cached = _cached(
+            cache,
+            # Namespaced: the integration scan shares this cache, and a card
+            # can be named after a domain.
+            f"card:{entry.name}",
+            _signature(files, unreadable_dirs, fingerprint, max_files, max_bytes),
+            lambda: _scan_card(
                 entry.name,
                 files,
                 unreadable_dirs,
                 rules,
                 max_files=max_files,
                 max_bytes=max_bytes,
-            )
-            if cache is not None:
-                cache[cache_key] = (signature, dict(result))
+            ),
+        )
+        cached_cards += was_cached
 
         cards[entry.name] = result
         for key in totals:

--- a/custom_components/breakage_radar/scanner.py
+++ b/custom_components/breakage_radar/scanner.py
@@ -355,9 +355,23 @@ def _scan_card(
             f"only minified bundles installed ({skipped_minified} skipped); "
             "the source repository's verdict applies"
         )
-    elif unreadable_dirs or unparsed or skipped_minified or skipped_files:
+    elif unreadable_dirs:
         status = "unknown"
-        reason = "scan truncated: some files were skipped or unreadable"
+        reason = "directory could not be fully read"
+    elif unparsed:
+        status = "unknown"
+        reason = f"{unparsed} of {len(files)} card file(s) could not be read"
+    elif skipped_minified or skipped_files:
+        status = "unknown"
+        skipped = []
+        if skipped_minified:
+            skipped.append(f"{skipped_minified} minified")
+        if skipped_files:
+            skipped.append(f"{skipped_files} over the size caps")
+        reason = (
+            f"scan truncated: {' and '.join(skipped)} of {len(files)} "
+            "card file(s) skipped"
+        )
     else:
         status = "clean"
 

--- a/tests/test_js_rules.py
+++ b/tests/test_js_rules.py
@@ -325,3 +325,30 @@ def test_card_repairs_issues_carry_the_card_name_and_clear(repo_root, sample_ind
     imminent_key = (DOMAIN, "card_imminent_power-card")
     assert imminent_key in ir.created
     assert ir.created[imminent_key]["translation_key"] == "card_imminent"
+
+
+def test_a_partly_skipped_card_says_what_was_skipped(repo_root, tmp_path):
+    """A card shipping source alongside a bundle is neither fully scanned nor
+    bundle-only, and that verdict has to name its cause: the reason string is
+    what a user sees when an integration is reported unknown."""
+    from custom_components.breakage_radar.scanner import scan_cards
+
+    manual = json.loads(
+        (repo_root / "data" / "manual_rules.json").read_text(encoding="utf-8")
+    )
+    rules = [
+        {**r, "matchable": True}
+        for r in manual["rules"]
+        if (r.get("match") or {}).get("type") == "js"
+    ]
+    card = tmp_path / "community" / "mixed-card"
+    card.mkdir(parents=True)
+    (card / "card.js").write_text("export const hello = 1;\n", encoding="utf-8")
+    (card / "card.min.js").write_text("const a=1;\n", encoding="utf-8")
+
+    result = scan_cards(str(card.parent), rules, current_version="2026.9")["cards"][
+        "mixed-card"
+    ]
+    assert result["status"] == "unknown"
+    assert result["reason"] == "scan truncated: 1 minified of 2 card file(s) skipped"
+    assert result["files_scanned"] == 1 and result["skipped_minified"] == 1


### PR DESCRIPTION
Follow-up to #32. The card scan shipped as a fork of the integration scan, and the review after merge measured the two paths at 59 to 76 percent line similarity. Cloning the neighbouring function is how the feature got written; this is the cleanup.

**One copy of each mechanism.** The directory walk, the mtime and size cache signature, the cache read-write, and the capped read loop each existed twice, differing only in which files they looked at. Four helpers now hold one copy of each, and both scans call them. The read loop is the one that matters: its caps accounting is easy to get subtly wrong twice, and it yields outside its `try` so an `OSError` raised by a matcher downstream is not miscounted as an unreadable file.

The per-directory loops in `scan_installed` and `scan_cards` are left alone. They still look alike, but they differ in the result key, the skip list, the cache namespace and the totals, and merging them needs a driver with ten parameters to save about 25 lines. That trade is not worth taking.

**Proven to change nothing.** `.cache/scan_characterise.py` records both scanners' full output over ten trees: every fixture tree, the seeded container config, tight file and byte caps, a warm cache, and a missing directory. Byte identical before and after the refactor, 27016 bytes.

**Second commit, a real change, kept separate.** Cards had one catch-all reason covering four causes, `scan truncated: some files were skipped or unreadable`, where integrations have named each cause with counts since 1.1.0. It now does the same. The characterization run showed why nobody had noticed: the branch was unreachable in every fixture and in the seeded container. A card shipping source alongside its bundle reaches it, and there is now a test for that case.

pytest 284 passed, 3 skipped. No version bump: `scanner.py` is internal and the report, index and sensor are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)