### PR TITLE
feat(action): run the scanner in an integration author's CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,8 +25,56 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m pip install --disable-pip-version-check --quiet pytest
+      - run: python -m pip install --disable-pip-version-check --quiet pytest pyyaml
       - run: python -m pytest
+
+  action:
+    name: action self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: A clean checkout passes
+        uses: ./
+        with:
+          path: tests/fixtures/false_positive
+
+      - name: A card repository is scanned, not refused
+        uses: ./
+        with:
+          path: tests/fixtures/plugins/config_entries_card
+
+      - name: A finding annotates without failing, which is the default
+        uses: ./
+        with:
+          path: tests/fixtures/true_positive
+
+      - name: fail-on any turns the same finding into a failure
+        id: gate
+        continue-on-error: true
+        uses: ./
+        with:
+          path: tests/fixtures/true_positive
+          fail-on: any
+
+      - name: The gate must have failed
+        if: steps.gate.outcome != 'failure'
+        run: |
+          echo "::error::fail-on: any did not fail the job"
+          exit 1
+
+      - name: A repository with nothing scannable is not reported as clean
+        id: unscannable
+        continue-on-error: true
+        uses: ./
+        with:
+          path: tests/fixtures/plugins/minified_card
+
+      - name: Nothing scannable must not pass
+        if: steps.unscannable.outcome != 'failure'
+        run: |
+          echo "::error::a repository of one minified bundle reported as clean"
+          exit 1
 
   hassfest:
     name: hassfest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,55 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
-## Unreleased
+## 1.9.0 — 2026-08-24
 
-Board and README only; the integration is unchanged, so there is no version bump.
+### The scanner runs in an integration author's CI (#21)
+
+Every finding this project produces lands on a *user*, and a user cannot fix an
+integration they did not write. `action.yml` puts the same scan in the
+maintainer's own pull requests, where it reaches the one person who can act on
+it.
+
+```yaml
+- uses: Booyaka101/hass-breakage-radar@v1.9.0
+```
+
+* **It annotates, it does not fail, by default.** A removal scheduled for
+  2027.8 turning an unrelated pull request red is how a check gets deleted
+  from a workflow file, and then it is not there for the one landing next
+  month either. `fail-on: imminent` gates on what is already released or
+  within `window-days` (90 by default, the same horizon the board leads with);
+  `fail-on: any` is the strict release gate. The CLI still defaults to `any`,
+  because a release gate is what it was already being used as.
+* **Annotations and a job summary, not one or the other.** GitHub displays 10
+  annotations per level per step and 50 per job, so thirty findings would show
+  as ten and read as though that was all of them. The summary table carries
+  every one. A finding that will fail the job is an `error`, the rest are
+  `warning`s, which also puts them on separate display budgets.
+* **Rules are pinned to the tag you pin.** `rules: pinned` (the default) reads
+  the rule set committed at that tag, so there is no network call in anyone
+  else's CI. `rules: index` fetches the published index instead, for rules
+  that stay current without a version bump. The daily crawl rewrites
+  `data/rules.json`, so pin an exact tag rather than a moving major.
+* **Card repositories work too, unasked.** `tools/check_local.py` now reads a
+  checkout without `custom_components/` as a Lovelace card repository and
+  scans its JavaScript wherever it lives, deduplicating `src` against `dist`
+  the way the crawler does. It used to exit 2 on all 748 plugin repositories
+  in the catalogue, which would have made the action useless to every one of
+  them.
+* **Nothing scannable is still not clean.** A card repository whose only file
+  is a minified bundle exits 2, not 0. The action's own self-test in CI
+  asserts that, along with the clean, annotated, gated and card cases, by
+  running the action against this repository's fixtures.
+
+`scan_sources()` in `rules_engine.py` is the one place that decides what a
+repository's Python and JavaScript add up to. The crawler reading a tarball and
+the self-check reading a directory now differ only in where the bytes come
+from, so a repository gets the same verdict whichever side looked at it.
+Verified as a no-op on the crawler over 16 fixture repositories covering both
+category branches and both status branches: identical records and findings.
+
+### Board and README
 
 * **The board states its own coverage gap
   ([#24](https://github.com/Booyaka101/hass-breakage-radar/issues/24)).** A new

--- a/README.md
+++ b/README.md
@@ -767,7 +767,23 @@ python tools/check_local.py /path/to/your-integration
 ```
 
 It exits `0` clean, `1` with findings, `2` if it could not check — so it works as a
-release gate in your own CI.
+release gate in your own CI. A checkout with `custom_components/` is read as an
+integration, one without is read as a Lovelace card repository; you do not have to say
+which.
+
+The same scan runs as a GitHub Action, which is the only way this project reaches the
+person who can actually fix a finding:
+
+```yaml
+- uses: actions/checkout@v7
+- uses: Booyaka101/hass-breakage-radar@v1.9.0
+```
+
+It annotates the exact line and writes a job summary, and by default it does **not**
+fail the job — a removal scheduled for 2027.8 turning an unrelated pull request red is
+how a check gets deleted from a workflow file. `fail-on: imminent` gates on what is
+close; `fail-on: any` is the strict gate. Inputs are documented in
+[the authors' guide](guides/for-integration-authors.md#in-your-ci-as-a-github-action).
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,78 @@
+name: "Home Assistant Breakage Radar"
+description: >-
+  Find Home Assistant APIs your custom integration or Lovelace card uses that
+  are already scheduled for removal, and which release removes them.
+author: "Booyaka101"
+
+branding:
+  icon: radio
+  color: purple
+
+inputs:
+  path:
+    description: "Directory to check. A checkout root, or a custom_components directory."
+    required: false
+    default: "."
+  fail-on:
+    description: >-
+      Which findings fail the job. never (annotate only, the default),
+      imminent (anything already past its release or within window-days), or
+      any (every finding, a strict release gate).
+    required: false
+    default: "never"
+  window-days:
+    description: "How far ahead fail-on: imminent reaches."
+    required: false
+    default: "90"
+  rules:
+    description: >-
+      pinned uses the rule set shipped with the version of this action you
+      pinned, with no network call. index fetches the published index, so
+      rules stay current without a version bump.
+    required: false
+    default: "pinned"
+  ha-version:
+    description: >-
+      Only report removals still ahead of this Home Assistant release. Leave
+      empty to report every future removal.
+    required: false
+    default: ""
+  python-version:
+    description: "Python used to parse your source. Newer parses more syntax."
+    required: false
+    default: "3.13"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Scan for scheduled removals
+      shell: bash
+      env:
+        RADAR_PATH: ${{ inputs.path }}
+        RADAR_FAIL_ON: ${{ inputs.fail-on }}
+        RADAR_WINDOW_DAYS: ${{ inputs.window-days }}
+        RADAR_RULES: ${{ inputs.rules }}
+        RADAR_HA_VERSION: ${{ inputs.ha-version }}
+        RADAR_ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        args=(
+          "$RADAR_PATH"
+          --format github
+          --fail-on "$RADAR_FAIL_ON"
+          --window-days "$RADAR_WINDOW_DAYS"
+        )
+        # "pinned" is the rule set committed at the tag this action was
+        # resolved from, so the version you pin is the pin. No network.
+        if [ "$RADAR_RULES" = "pinned" ]; then
+          args+=(--rules "$RADAR_ACTION_PATH/data/rules.json")
+        fi
+        if [ -n "$RADAR_HA_VERSION" ]; then
+          args+=(--ha-version "$RADAR_HA_VERSION")
+        fi
+        python "$RADAR_ACTION_PATH/tools/check_local.py" "${args[@]}"

--- a/custom_components/breakage_radar/manifest.json
+++ b/custom_components/breakage_radar/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/Booyaka101/hass-breakage-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.8.0"
+  "version": "1.9.0"
 }

--- a/custom_components/breakage_radar/rules_engine.py
+++ b/custom_components/breakage_radar/rules_engine.py
@@ -819,6 +819,11 @@ def _match_call_hass_argument(
 #: the callers: a type declaration describes the API, it does not call it.
 JS_SUFFIXES = (".js", ".mjs", ".ts")
 
+#: Directory names holding somebody else's code. A finding in here is not the
+#: repository's to fix. Every walker -- tarball, checkout, installed tree --
+#: takes the list from here so all three judge the same files.
+VENDOR_DIRECTORIES = frozenset({"site-packages", "node_modules", ".venv", "vendor"})
+
 #: A single line longer than this is a bundler's output, not source.
 JS_MAX_LINE_LENGTH = 5000
 
@@ -1070,6 +1075,35 @@ def match_source(
             )
 
     findings.sort(key=lambda f: (f.file, f.line, f.rule_id))
+    return findings
+
+
+def scan_sources(
+    python: Iterable[tuple[str, str | bytes]],
+    javascript: Iterable[tuple[str, str]],
+    rules: Iterable[Rule],
+    stats: ScanStats | None = None,
+) -> list[Finding]:
+    """Every finding for one repository's Python and JavaScript.
+
+    JavaScript is deduplicated per rule across the whole repository, Python is
+    not: a card shipping ``src`` and ``dist`` has one thing to fix, two Python
+    call sites are two. Both the crawler (reading a tarball) and the local
+    self-check (reading a directory) call this, so a repository gets the same
+    verdict whichever side looked at it.
+    """
+    rules = list(rules)
+    findings = [
+        finding
+        for path, source in python
+        for finding in match_source(path, source, rules, stats)
+    ]
+    js_findings = [
+        finding
+        for path, text in javascript
+        for finding in match_js_source(path, text, rules, stats)
+    ]
+    findings.extend(dedupe_js_findings(js_findings))
     return findings
 
 

--- a/guides/for-integration-authors.md
+++ b/guides/for-integration-authors.md
@@ -54,8 +54,8 @@ checkout you point it at. Real output against this repository's own test
 fixture:
 
 ```
-INFO breakage_radar.tools: 34 matchable rule(s) from https://booyaka101.github.io/hass-breakage-radar/index.json
-INFO breakage_radar.tools: scanned 1 file(s) across 1 component(s); 0 unparseable, 0 skipped
+INFO breakage_radar.tools: 41 matchable rule(s) from https://booyaka101.github.io/hass-breakage-radar/index.json
+INFO breakage_radar.tools: scanned 1 file(s); 0 unparseable, 0 skipped
 
 custom_components/fixture_tracker/device_tracker.py:12
     breaks in Home Assistant 2027.5 (high confidence, rule legacy-device-tracker-platform)
@@ -75,18 +75,25 @@ Exit codes make it usable as a release gate in your own CI:
 
 | Code | Meaning |
 |---|---|
-| `0` | nothing found |
-| `1` | at least one finding |
-| `2` | **could not check** — no `custom_components/`, unreachable index, or no rules left |
+| `0` | nothing found, or nothing that `--fail-on` says is worth failing over |
+| `1` | at least one finding, and `--fail-on` counts it |
+| `2` | **could not check** — nothing scannable, unreachable index, or no rules left |
 
 Exit 2 is deliberately not exit 0. A check that could not run has proved
-nothing, and must never be mistaken for a clean result.
+nothing, and must never be mistaken for a clean result. A card repository
+whose only file is a minified bundle lands here for the same reason.
+
+A checkout with `custom_components/` is read as an integration: its Python,
+plus any frontend module shipped alongside it. A checkout without one is read
+as a Lovelace card repository, and its JavaScript is scanned wherever it lives.
+You do not have to say which.
 
 Useful flags:
 
 ```bash
 python tools/check_local.py . --ha-version 2027.5   # only removals still ahead of 2027.5
 python tools/check_local.py . --rules data/rules.json   # offline, no index fetch
+python tools/check_local.py . --fail-on imminent    # only fail on what is close
 ```
 
 > **Use Python 3.12 or newer, ideally 3.14.** The checker parses your code with
@@ -94,6 +101,57 @@ python tools/check_local.py . --rules data/rules.json   # offline, no index fetc
 > (PEP 695 `type X = ...`, PEP 758 `except A, B:`) fails to parse and is
 > reported as unparseable rather than checked. The count of unparseable files is
 > always printed — if it is not zero, upgrade before trusting the result.
+
+---
+
+## In your CI, as a GitHub Action
+
+Same scanner, same rules, wired into pull requests so the finding lands on the
+line rather than in someone else's Home Assistant log.
+
+```yaml
+name: Breakage Radar
+on: [pull_request]
+
+jobs:
+  removals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Booyaka101/hass-breakage-radar@v1.9.0
+```
+
+That is the whole thing. It works unchanged on a card repository.
+
+By default it **annotates and does not fail**. A removal scheduled for 2027.8
+turning an unrelated pull request red is how a check gets deleted from a
+workflow file, and then it is not there to warn you about the one landing next
+month either. When you want a gate, ask for one:
+
+```yaml
+      - uses: Booyaka101/hass-breakage-radar@v1.9.0
+        with:
+          fail-on: imminent    # already released, or within window-days
+          window-days: "90"
+```
+
+| Input | Default | What it does |
+|---|---|---|
+| `path` | `.` | checkout root, or a `custom_components` directory |
+| `fail-on` | `never` | `never`, `imminent`, or `any` |
+| `window-days` | `90` | how far ahead `imminent` reaches |
+| `rules` | `pinned` | `pinned` uses the rules committed at the tag you pinned, with no network call. `index` fetches the published index instead |
+| `ha-version` | *(empty)* | only report removals still ahead of this release |
+| `python-version` | `3.13` | the interpreter that parses your source |
+
+Findings come out as annotations on the exact line, **and** as a job summary
+table. Both, because GitHub only displays 10 annotations per level per step and
+50 per job — with the summary, thirty findings read as thirty rather than as
+ten.
+
+Pin an exact tag rather than a moving major. `data/rules.json` is rewritten by
+the daily crawl, so a floating ref would quietly change what your CI checks
+against; a tag is a rule set you chose.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-breakage-radar"
-version = "1.8.0"
+version = "1.9.0"
 description = "Find out which of your Home Assistant custom integrations stop working, and in which future release."
 readme = "README.md"
 license = { text = "MIT" }
@@ -32,7 +32,9 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest>=7.4"]
+# PyYAML only parses action.yml in the tests. Nothing shipped imports it, so
+# the integration's "requirements": [] stays honest.
+dev = ["pytest>=7.4", "pyyaml>=6"]
 
 [project.urls]
 Homepage = "https://github.com/Booyaka101/hass-breakage-radar"

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,0 +1,78 @@
+"""The GitHub Action is a wrapper, so the thing to test is that it still fits.
+
+An action that passes a flag the CLI dropped fails in somebody else's CI, on
+their pull request, with an argparse traceback. These assertions are cheap and
+that failure is not.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tools.check_local import build_parser
+
+yaml = pytest.importorskip("yaml", reason="PyYAML is not a runtime dependency")
+
+
+@pytest.fixture
+def action(repo_root):
+    return yaml.safe_load((repo_root / "action.yml").read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def scan_step(action):
+    steps = action["runs"]["steps"]
+    return next(step for step in steps if "run" in step)
+
+
+def test_every_flag_the_action_passes_still_exists(scan_step):
+    known = {
+        option
+        for act in build_parser()._actions
+        for option in act.option_strings
+    }
+    used = set(re.findall(r"(?<![\w-])--[a-z][a-z-]+", scan_step["run"]))
+    assert used <= known, f"action.yml passes flags the CLI does not accept: {used - known}"
+
+
+@pytest.mark.parametrize(
+    ("field", "flag"),
+    [("fail-on", "--fail-on"), ("path", None)],
+)
+def test_declared_defaults_are_values_the_cli_accepts(action, field, flag):
+    default = action["inputs"][field]["default"]
+    if flag is None:
+        return
+    choices = next(
+        act.choices for act in build_parser()._actions if flag in act.option_strings
+    )
+    assert default in choices
+
+
+def test_the_default_is_not_a_release_gate(action):
+    """A deprecation a year out failing an unrelated pull request is how this
+    gets uninstalled. The CLI defaults to `any`; the action must not."""
+    assert action["inputs"]["fail-on"]["default"] == "never"
+
+
+def test_pinned_rules_point_at_a_file_that_ships(repo_root, scan_step):
+    assert "$RADAR_ACTION_PATH/data/rules.json" in scan_step["run"]
+    assert (repo_root / "data" / "rules.json").is_file()
+
+
+def test_the_scan_step_reaches_inputs_through_the_environment(scan_step):
+    """Interpolating ${{ inputs.x }} straight into a shell line lets a branch
+    name run as code. Every input goes through env instead."""
+    assert "${{" not in scan_step["run"]
+    assert set(scan_step["env"]) >= {"RADAR_PATH", "RADAR_FAIL_ON", "RADAR_RULES"}
+
+
+def test_the_action_declares_every_input_it_uses(action, scan_step):
+    used = set(re.findall(r"\$\{\{\s*inputs\.([a-z-]+)\s*\}\}", yaml.dump(action)))
+    assert used <= set(action["inputs"])
+
+
+def test_it_is_a_composite_action_with_no_container_pull(action):
+    assert action["runs"]["using"] == "composite"

--- a/tests/test_check_local.py
+++ b/tests/test_check_local.py
@@ -8,10 +8,12 @@ must never be reported as clean.
 from __future__ import annotations
 
 import json
+from datetime import date, timedelta
 
 import pytest
 
-from tools.check_local import main
+from tools.check_local import is_blocking, main
+from tools.rules_engine import Finding
 
 
 @pytest.fixture
@@ -134,3 +136,223 @@ def test_an_unreachable_index_cannot_be_checked(fixtures_dir):
         ]
     )
     assert code == 2
+
+
+# --------------------------------------------------------------------------- #
+# Card repositories
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def card_rules(tmp_path):
+    """The two device-registry WebSocket fields the card fixtures read."""
+    path = tmp_path / "card-rules.json"
+    path.write_text(
+        json.dumps(
+            {
+                "rules": [
+                    {
+                        "id": f"device-registry-{token.replace('_', '-')}-field",
+                        "breaks_in": "2027.8",
+                        "message": f"Reads {token} from a device registry result.",
+                        "source": "https://developers.home-assistant.io/blog/",
+                        "confidence": "high",
+                        "match": {"type": "js", "token": token},
+                    }
+                    for token in ("config_entries", "primary_config_entry")
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_a_card_repository_is_scanned_without_custom_components(
+    fixtures_dir, card_rules, capsys
+):
+    """748 of the catalogue's repositories are cards. Exit 2 for all of them
+    would make the action useless to every one."""
+    code = main(
+        [str(fixtures_dir / "plugins" / "config_entries_card"), "--rules", str(card_rules)]
+    )
+    assert code == 1
+    assert "power-card.js" in capsys.readouterr().out
+
+
+def test_a_card_shipping_source_and_bundle_reports_the_source_once(
+    fixtures_dir, card_rules, capsys
+):
+    code = main(
+        [str(fixtures_dir / "plugins" / "ts_plus_bundle"), "--rules", str(card_rules)]
+    )
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "1 finding(s)." in out
+    assert "src/card.ts" in out
+    assert "dist/card.js" not in out
+
+
+def test_a_repository_of_nothing_but_a_bundle_is_not_clean(
+    fixtures_dir, card_rules
+):
+    """Its only file is skipped, so nothing was analysed. That is exit 2."""
+    assert (
+        main([str(fixtures_dir / "plugins" / "minified_card"), "--rules", str(card_rules)])
+        == 2
+    )
+
+
+# --------------------------------------------------------------------------- #
+# --fail-on
+# --------------------------------------------------------------------------- #
+
+
+def _finding(breaks_in: str) -> Finding:
+    return Finding(
+        rule_id="r", breaks_in=breaks_in, file="f.py", line=1, confidence="high"
+    )
+
+
+def test_fail_on_never_reports_without_failing(fixtures_dir, local_rules, capsys):
+    code = main(
+        [str(fixtures_dir / "true_positive"), "--rules", str(local_rules), "--fail-on", "never"]
+    )
+    assert code == 0
+    assert "1 finding(s)." in capsys.readouterr().out
+
+
+def test_fail_on_any_is_the_default_release_gate():
+    assert is_blocking(_finding("2099.1"), "any", 90, date(2026, 8, 24))
+
+
+def test_fail_on_imminent_uses_the_window():
+    today = date(2026, 8, 24)
+    # 2026.10 lands 7 October 2026, 44 days out; 2027.8 is years away.
+    assert is_blocking(_finding("2026.10"), "imminent", 90, today)
+    assert not is_blocking(_finding("2027.8"), "imminent", 90, today)
+    assert not is_blocking(_finding("2026.10"), "imminent", 30, today)
+
+
+def test_fail_on_imminent_covers_a_release_that_already_landed():
+    assert is_blocking(_finding("2026.1"), "imminent", 90, date(2026, 8, 24))
+
+
+def test_fail_on_imminent_forms_no_opinion_about_an_undated_label():
+    """Same refusal to guess as the integration: reported, never fatal."""
+    assert not is_blocking(_finding("next"), "imminent", 3650, date(2026, 8, 24))
+
+
+def test_an_imminent_finding_fails_the_job_end_to_end(fixtures_dir, tmp_path, capsys):
+    """Dated from today so the assertion cannot rot."""
+    soon = date.today().replace(day=1) + timedelta(days=40)
+    rules = tmp_path / "soon.json"
+    rules.write_text(
+        json.dumps(
+            {
+                "rules": [
+                    {
+                        "id": "legacy-device-tracker-platform",
+                        "breaks_in": f"{soon.year}.{soon.month}",
+                        "message": "Implements the legacy device tracker platform API.",
+                        "confidence": "high",
+                        "match": {
+                            "type": "moduledef",
+                            "names": ["setup_scanner"],
+                            "files": ["device_tracker.py"],
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    args = [str(fixtures_dir / "true_positive"), "--rules", str(rules)]
+    assert main([*args, "--fail-on", "imminent"]) == 1
+    assert main([*args, "--fail-on", "imminent", "--window-days", "1"]) == 0
+    assert "finding(s)." in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# --format github
+# --------------------------------------------------------------------------- #
+
+
+def test_github_format_annotates_the_exact_line(
+    fixtures_dir, local_rules, tmp_path, monkeypatch, capsys
+):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    code = main(
+        [
+            str(fixtures_dir / "true_positive"),
+            "--rules",
+            str(local_rules),
+            "--format",
+            "github",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "::error file=custom_components/fixture_tracker/device_tracker.py," in out
+    assert "line=12," in out
+    assert "title=Breaks in Home Assistant 2027.5" in out
+    # A blocking finding is an error, so it survives the 10-warnings cap on its
+    # own budget.
+    assert "::warning" not in out
+
+
+def test_github_format_downgrades_what_will_not_fail_the_job(
+    fixtures_dir, local_rules, capsys
+):
+    main(
+        [
+            str(fixtures_dir / "true_positive"),
+            "--rules",
+            str(local_rules),
+            "--format",
+            "github",
+            "--fail-on",
+            "never",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "::warning file=" in out
+    assert "::error" not in out
+
+
+def test_github_format_writes_every_finding_to_the_job_summary(
+    fixtures_dir, card_rules, tmp_path, monkeypatch
+):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    main(
+        [
+            str(fixtures_dir / "plugins" / "config_entries_card"),
+            "--rules",
+            str(card_rules),
+            "--format",
+            "github",
+        ]
+    )
+    written = summary.read_text(encoding="utf-8")
+    assert "## Home Assistant Breakage Radar" in written
+    assert "| Breaks in | When | File | Rule | Confidence |" in written
+    assert "`power-card.js:" in written
+    assert "not a guarantee of breakage" in written
+
+
+def test_github_format_survives_no_summary_file(fixtures_dir, local_rules, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    assert (
+        main(
+            [
+                str(fixtures_dir / "true_positive"),
+                "--rules",
+                str(local_rules),
+                "--format",
+                "github",
+            ]
+        )
+        == 1
+    )

--- a/tools/check_local.py
+++ b/tools/check_local.py
@@ -1,7 +1,7 @@
 """Check a checkout on this machine against the published breakage index.
 
-This is the self-check for integration *authors*: the daily crawler only
-visits repositories listed in the HACS catalogue, so a fork, a private
+This is the self-check for integration and card *authors*: the daily crawler
+only visits repositories listed in the HACS catalogue, so a fork, a private
 integration or an unreleased branch can never be answered by the board. This
 runs the exact same matchers over a directory you point it at.
 
@@ -9,15 +9,30 @@ runs the exact same matchers over a directory you point it at.
     python tools/check_local.py ~/src/my-integration --ha-version 2027.5
     python tools/check_local.py . --rules data/rules.json    # offline
 
-It accepts either a repository checkout containing ``custom_components/`` or a
-``custom_components`` directory itself, and exits 1 when it finds something --
-so it works as a release gate in CI.
+It accepts a repository checkout, or a ``custom_components`` directory itself.
+A checkout with ``custom_components/`` is read as an integration: its Python,
+plus any frontend module shipped alongside. A checkout without one is read as
+a Lovelace card repository and its JavaScript is scanned wherever it lives.
+
+Exit codes are the contract, because this runs in an author's own CI:
+
+* ``0`` nothing to report
+* ``1`` findings, and ``--fail-on`` says they are worth failing over
+* ``2`` could not check, which is never the same thing as clean
+
+``--fail-on`` defaults to ``any``, so the default is the release gate it has
+always been. ``--format github`` turns the findings into workflow annotations
+and a job summary; ``action.yml`` in the repository root is a thin wrapper
+around exactly that.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+from collections.abc import Iterator
+from datetime import date
 from pathlib import Path
 
 if __package__ in (None, ""):  # pragma: no cover - direct script execution
@@ -25,11 +40,17 @@ if __package__ in (None, ""):  # pragma: no cover - direct script execution
 
 from tools.common import LOGGER, http_get_json, read_json, setup_logging  # noqa: E402
 from tools.rules_engine import (  # noqa: E402
+    JS_SUFFIXES,
+    VENDOR_DIRECTORIES,
+    Finding,
+    Rule,
     ScanStats,
     is_future,
     load_rules,
-    match_source,
+    looks_minified_js,
+    scan_sources,
 )
+from tools.schedule import days_until, describe_when  # noqa: E402
 
 INDEX_URL = "https://booyaka101.github.io/hass-breakage-radar/index.json"
 
@@ -37,9 +58,11 @@ INDEX_URL = "https://booyaka101.github.io/hass-breakage-radar/index.json"
 MAX_FILES = 400
 MAX_BYTES = 1_000_000
 
-_SKIP_DIRECTORIES = frozenset(
-    {"__pycache__", ".git", ".github", "site-packages", "node_modules", "vendor"}
-)
+#: How far ahead ``--fail-on imminent`` still counts as imminent. The board
+#: leads with the same 90 days.
+WINDOW_DAYS = 90
+
+_SKIP_DIRECTORIES = frozenset({"__pycache__", ".git", ".github"}) | VENDOR_DIRECTORIES
 
 
 def find_components_dir(target: Path) -> Path | None:
@@ -52,20 +75,213 @@ def find_components_dir(target: Path) -> Path | None:
     return None
 
 
+def _walkable(relative: Path) -> bool:
+    """Neither vendored nor hidden. A finding in ``node_modules`` is not the
+    repository's to fix, and ``.git`` is not source."""
+    return not any(
+        part in _SKIP_DIRECTORIES or part.startswith(".") for part in relative.parts[:-1]
+    )
+
+
 def iter_python_files(domain_dir: Path) -> list[tuple[Path, str]]:
     """``[(path, posix path relative to the component directory)]``."""
-    files: list[tuple[Path, str]] = []
-    for path in sorted(domain_dir.rglob("*.py")):
-        relative = path.relative_to(domain_dir)
-        if any(part in _SKIP_DIRECTORIES for part in relative.parts):
-            continue
-        if any(part.startswith(".") for part in relative.parts):
-            continue
-        files.append((path, relative.as_posix()))
-    return files
+    return [
+        (path, path.relative_to(domain_dir).as_posix())
+        for path in sorted(domain_dir.rglob("*.py"))
+        if _walkable(path.relative_to(domain_dir))
+    ]
 
 
-def main(argv: list[str] | None = None) -> int:
+def read_python(
+    components: Path, skipped: dict[str, int]
+) -> Iterator[tuple[str, bytes]]:
+    """``(custom_components/... path, source)`` for every component on disk."""
+    for domain_dir in _component_dirs(components):
+        files = iter_python_files(domain_dir)
+        for position, (path, relative) in enumerate(files):
+            if position >= MAX_FILES:
+                skipped["capped"] += len(files) - position
+                break
+            source = _read_bytes(path, skipped)
+            if source is not None:
+                yield f"custom_components/{domain_dir.name}/{relative}", source
+
+
+def read_javascript(root: Path, skipped: dict[str, int]) -> Iterator[tuple[str, str]]:
+    """``(path, text)`` for every scannable frontend file below ``root``.
+
+    A ``.d.ts`` declares the API rather than calling it, and a bundle is never
+    guessed at: it is counted so a card repository whose only file is minified
+    reads as *not analysed* instead of clean.
+    """
+    prefix = "custom_components/" if root.name == "custom_components" else ""
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if not _walkable(relative):
+            continue
+        name = relative.as_posix()
+        if not name.endswith(JS_SUFFIXES) or name.endswith(".d.ts"):
+            continue
+        source = _read_bytes(path, skipped)
+        if source is None:
+            continue
+        text = source.decode("utf-8", "replace")
+        if looks_minified_js(name, text):
+            skipped["minified"] += 1
+            continue
+        yield prefix + name, text
+
+
+def _component_dirs(components: Path) -> list[Path]:
+    return sorted(
+        entry
+        for entry in components.iterdir()
+        if entry.is_dir()
+        and entry.name not in _SKIP_DIRECTORIES
+        and not entry.name.startswith(".")
+    )
+
+
+def _read_bytes(path: Path, skipped: dict[str, int]) -> bytes | None:
+    try:
+        if path.stat().st_size > MAX_BYTES:
+            skipped["too_big"] += 1
+            return None
+        return path.read_bytes()
+    except OSError as err:
+        LOGGER.warning("could not read %s: %s", path, err)
+        skipped["unreadable"] += 1
+        return None
+
+
+def is_blocking(finding: Finding, policy: str, window_days: int, today: date) -> bool:
+    """Whether this finding should fail the job under ``policy``.
+
+    ``imminent`` forms no opinion about a release label that does not map to a
+    date, the same way the integration refuses to guess one. It is still
+    reported, just not fatal.
+    """
+    if policy == "never":
+        return False
+    if policy == "any":
+        return True
+    days = days_until(finding.breaks_in, today)
+    return days is not None and days <= window_days
+
+
+def _escape(value: str, *, property_value: bool = False) -> str:
+    """Workflow-command escaping. Property values need the separators too."""
+    out = value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    if property_value:
+        out = out.replace(":", "%3A").replace(",", "%2C")
+    return out
+
+
+def _describe(finding: Finding, rule: Rule | None, today: date) -> tuple[str, str]:
+    """``(title, one-line message)`` shared by both output formats."""
+    when = describe_when(finding.breaks_in, days_until(finding.breaks_in, today))
+    title = f"Breaks in Home Assistant {finding.breaks_in} ({when})"
+    parts = [(rule.message if rule else "").strip()[:400] or finding.symbol]
+    parts.append(f"[{finding.confidence} confidence, rule {finding.rule_id}]")
+    if rule and rule.source:
+        parts.append(rule.source)
+    return title, " ".join(part for part in parts if part)
+
+
+def render_text(findings: list[Finding], rules: dict[str, Rule], today: date) -> None:
+    print()
+    for finding in findings:
+        rule = rules.get(finding.rule_id)
+        print(f"{finding.file}:{finding.line}")
+        print(
+            f"    breaks in Home Assistant {finding.breaks_in} "
+            f"({finding.confidence} confidence, rule {finding.rule_id})"
+        )
+        if rule and rule.message:
+            print(f"    {rule.message[:200]}")
+        if rule and rule.source:
+            print(f"    {rule.source}")
+        print()
+    print(f"{len(findings)} finding(s).")
+
+
+def render_github(
+    findings: list[Finding],
+    rules: dict[str, Rule],
+    today: date,
+    blocking: set[int],
+) -> None:
+    """Workflow annotations, plus the whole list as a job summary.
+
+    Both, because GitHub only displays 10 annotations per level per step and
+    50 per job. A repository with thirty findings would otherwise show ten and
+    read as though that was all of them.
+    """
+    for index, finding in enumerate(findings):
+        title, message = _describe(finding, rules.get(finding.rule_id), today)
+        level = "error" if index in blocking else "warning"
+        print(
+            f"::{level} file={_escape(finding.file, property_value=True)},"
+            f"line={finding.line},"
+            f"title={_escape(title, property_value=True)}::{_escape(message)}"
+        )
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    lines = [
+        "## Home Assistant Breakage Radar",
+        "",
+        f"{len(findings)} finding(s) in this checkout.",
+        "",
+        "| Breaks in | When | File | Rule | Confidence |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for finding in findings:
+        when = describe_when(finding.breaks_in, days_until(finding.breaks_in, today))
+        lines.append(
+            f"| {finding.breaks_in} | {when} | `{finding.file}:{finding.line}` "
+            f"| {finding.rule_id} | {finding.confidence} |"
+        )
+    lines.extend(
+        [
+            "",
+            "A finding is a static-analysis result, not a guarantee of breakage. "
+            "Full detail, and how to report one you think is wrong: "
+            "<https://github.com/Booyaka101/hass-breakage-radar/blob/main/guides/"
+            "for-integration-authors.md>",
+            "",
+        ]
+    )
+    try:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines))
+    except OSError as err:  # pragma: no cover - the runner always provides it
+        LOGGER.warning("could not write the job summary: %s", err)
+
+
+def _load_rules_payload(args: argparse.Namespace) -> tuple[list[dict], str] | None:
+    if args.rules:
+        payload = read_json(args.rules, default=None)
+        if payload is None:
+            LOGGER.error("%s not found", args.rules)
+            return None
+        return payload.get("rules", payload), str(args.rules)
+    try:
+        index = http_get_json(args.index)
+    except Exception as err:  # noqa: BLE001 - any transport problem is fatal here
+        LOGGER.error(
+            "could not fetch %s (%s). Use --rules data/rules.json to run offline.",
+            args.index,
+            err,
+        )
+        return None
+    return index.get("rules", []), args.index
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
         "target",
@@ -88,38 +304,41 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="only report removals still ahead of this Home Assistant release",
     )
+    parser.add_argument(
+        "--format",
+        choices=("text", "github"),
+        default="text",
+        help="github emits workflow annotations and a job summary",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("never", "imminent", "any"),
+        default="any",
+        help="which findings exit 1; imminent means within --window-days",
+    )
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=WINDOW_DAYS,
+        help=f"how far ahead --fail-on imminent reaches (default {WINDOW_DAYS})",
+    )
     parser.add_argument("-v", "--verbose", action="store_true")
-    args = parser.parse_args(argv)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
     setup_logging(args.verbose)
 
-    components = find_components_dir(args.target.expanduser().resolve())
-    if components is None:
-        LOGGER.error(
-            "no custom_components/ directory in %s -- point this at your "
-            "repository checkout or at the custom_components directory itself",
-            args.target,
-        )
+    target = args.target.expanduser().resolve()
+    if not target.is_dir():
+        LOGGER.error("%s is not a directory", args.target)
         return 2
 
-    if args.rules:
-        payload = read_json(args.rules, default=None)
-        if payload is None:
-            LOGGER.error("%s not found", args.rules)
-            return 2
-        rules_payload = payload.get("rules", payload)
-        source_label = str(args.rules)
-    else:
-        try:
-            index = http_get_json(args.index)
-        except Exception as err:  # noqa: BLE001 - any transport problem is fatal here
-            LOGGER.error(
-                "could not fetch %s (%s). Use --rules data/rules.json to run offline.",
-                args.index,
-                err,
-            )
-            return 2
-        rules_payload = index.get("rules", [])
-        source_label = args.index
+    rules_source = _load_rules_payload(args)
+    if rules_source is None:
+        return 2
+    rules_payload, source_label = rules_source
 
     rules = [rule for rule in load_rules(rules_payload) if rule.matchable]
     if args.ha_version:
@@ -129,51 +348,44 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     LOGGER.info("%d matchable rule(s) from %s", len(rules), source_label)
 
-    messages = {rule.id: rule for rule in load_rules(rules_payload)}
+    components = find_components_dir(target)
+    skipped = {"capped": 0, "too_big": 0, "unreadable": 0, "minified": 0}
     stats = ScanStats()
-    findings = []
-    skipped = 0
 
-    domains = sorted(
-        d for d in components.iterdir() if d.is_dir() and d.name not in _SKIP_DIRECTORIES
-    )
-    if not domains:
+    if components is None:
+        # No custom_components: read it as a Lovelace card repository, whose
+        # card can live anywhere in the tree.
+        LOGGER.info("no custom_components/ in %s; scanning as a card repository", target)
+        findings = scan_sources((), read_javascript(target, skipped), rules, stats)
+    elif not _component_dirs(components):
         LOGGER.error("%s contains no component directories", components)
         return 2
-
-    for domain_dir in domains:
-        files = iter_python_files(domain_dir)
-        for position, (path, relative) in enumerate(files):
-            if position >= MAX_FILES:
-                skipped += len(files) - position
-                break
-            try:
-                if path.stat().st_size > MAX_BYTES:
-                    skipped += 1
-                    continue
-                source = path.read_bytes()
-            except OSError as err:
-                LOGGER.warning("could not read %s: %s", path, err)
-                skipped += 1
-                continue
-            findings.extend(
-                match_source(
-                    f"custom_components/{domain_dir.name}/{relative}",
-                    source,
-                    rules,
-                    stats,
-                )
-            )
+    else:
+        findings = scan_sources(
+            read_python(components, skipped),
+            read_javascript(components, skipped),
+            rules,
+            stats,
+        )
 
     LOGGER.info(
-        "scanned %d file(s) across %d component(s); %d unparseable, %d skipped",
+        "scanned %d file(s); %d unparseable, %d skipped",
         stats.files_scanned,
-        len(domains),
         len(stats.syntax_errors),
-        skipped,
+        sum(skipped.values()),
     )
     for problem in stats.syntax_errors:
         LOGGER.warning("could not parse %s", problem)
+
+    if stats.files_scanned == 0:
+        # Nothing was read, so nothing was proved. Reporting this as clean is
+        # the one failure mode this tool exists to avoid.
+        LOGGER.error(
+            "no scannable source in %s (%d file(s) skipped) -- nothing was checked",
+            target,
+            sum(skipped.values()),
+        )
+        return 2
 
     if not findings:
         # Plain ASCII: a Windows console defaults to cp1252 and raises on
@@ -182,20 +394,26 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     findings.sort(key=lambda f: (f.breaks_in, f.file, f.line))
-    print()
-    for finding in findings:
-        rule = messages.get(finding.rule_id)
-        print(f"{finding.file}:{finding.line}")
-        print(
-            f"    breaks in Home Assistant {finding.breaks_in} "
-            f"({finding.confidence} confidence, rule {finding.rule_id})"
+    messages = {rule.id: rule for rule in load_rules(rules_payload)}
+    today = date.today()
+    blocking = {
+        index
+        for index, finding in enumerate(findings)
+        if is_blocking(finding, args.fail_on, args.window_days, today)
+    }
+
+    if args.format == "github":
+        render_github(findings, messages, today, blocking)
+    else:
+        render_text(findings, messages, today)
+
+    if not blocking:
+        LOGGER.info(
+            "%d finding(s), none of them fatal under --fail-on %s",
+            len(findings),
+            args.fail_on,
         )
-        if rule and rule.message:
-            print(f"    {rule.message[:200]}")
-        if rule and rule.source:
-            print(f"    {rule.source}")
-        print()
-    print(f"{len(findings)} finding(s).")
+        return 0
     return 1
 
 

--- a/tools/rules_engine.py
+++ b/tools/rules_engine.py
@@ -819,6 +819,11 @@ def _match_call_hass_argument(
 #: the callers: a type declaration describes the API, it does not call it.
 JS_SUFFIXES = (".js", ".mjs", ".ts")
 
+#: Directory names holding somebody else's code. A finding in here is not the
+#: repository's to fix. Every walker -- tarball, checkout, installed tree --
+#: takes the list from here so all three judge the same files.
+VENDOR_DIRECTORIES = frozenset({"site-packages", "node_modules", ".venv", "vendor"})
+
 #: A single line longer than this is a bundler's output, not source.
 JS_MAX_LINE_LENGTH = 5000
 
@@ -1070,6 +1075,35 @@ def match_source(
             )
 
     findings.sort(key=lambda f: (f.file, f.line, f.rule_id))
+    return findings
+
+
+def scan_sources(
+    python: Iterable[tuple[str, str | bytes]],
+    javascript: Iterable[tuple[str, str]],
+    rules: Iterable[Rule],
+    stats: ScanStats | None = None,
+) -> list[Finding]:
+    """Every finding for one repository's Python and JavaScript.
+
+    JavaScript is deduplicated per rule across the whole repository, Python is
+    not: a card shipping ``src`` and ``dist`` has one thing to fix, two Python
+    call sites are two. Both the crawler (reading a tarball) and the local
+    self-check (reading a directory) call this, so a repository gets the same
+    verdict whichever side looked at it.
+    """
+    rules = list(rules)
+    findings = [
+        finding
+        for path, source in python
+        for finding in match_source(path, source, rules, stats)
+    ]
+    js_findings = [
+        finding
+        for path, text in javascript
+        for finding in match_js_source(path, text, rules, stats)
+    ]
+    findings.extend(dedupe_js_findings(js_findings))
     return findings
 
 

--- a/tools/scan.py
+++ b/tools/scan.py
@@ -52,15 +52,14 @@ from tools.common import (  # noqa: E402
 from tools.rules_engine import (  # noqa: E402
     ENGINE_VERSION,
     JS_SUFFIXES,
+    VENDOR_DIRECTORIES,
     Finding,
     Rule,
     ScanStats,
-    dedupe_js_findings,
     load_rules,
     looks_minified_js,
-    match_js_source,
-    match_source,
     matchable_rules,
+    scan_sources,
 )
 from tools.upstream import annotate  # noqa: E402
 
@@ -70,8 +69,9 @@ CODELOAD = "https://codeload.github.com/{full_name}/tar.gz/{ref}"
 #: firmware blobs; the Python we care about is always tiny.
 MAX_TARBALL_BYTES = 80 * 1024 * 1024
 
-#: Skip vendored third-party code shipped inside a custom component.
-VENDOR_MARKERS = ("/site-packages/", "/node_modules/", "/.venv/", "/vendor/")
+#: Skip vendored third-party code shipped inside a custom component. Tarball
+#: paths are filtered by substring, so the shared name list becomes markers.
+VENDOR_MARKERS = tuple(f"/{name}/" for name in sorted(VENDOR_DIRECTORIES))
 
 
 def candidate_refs(last_version: str) -> list[str]:
@@ -258,23 +258,18 @@ def scan_repo(
 
     try:
         stats = ScanStats()
-        findings: list[Finding] = []
-        if category == "plugin":
-            domains: list[str] = []
-            js_findings: list[Finding] = []
-            for path, text in iter_javascript(body, skipped, whole_repo=True):
-                js_findings.extend(match_js_source(path, text, rules, stats))
-            findings = dedupe_js_findings(js_findings)
-        else:
-            domains = iter_manifest_domains(body)
-            for path, source in iter_component_python(body):
-                findings.extend(match_source(path, source, rules, stats))
-            # Frontend modules shipped inside custom_components/ break on the
-            # WebSocket rules the same way a standalone card does.
-            js_findings = []
-            for path, text in iter_javascript(body, skipped, whole_repo=False):
-                js_findings.extend(match_js_source(path, text, rules, stats))
-            findings.extend(dedupe_js_findings(js_findings))
+        # A plugin repository keeps its card anywhere, so the whole tree is
+        # walked and there is no Python to read. An integration ships frontend
+        # modules inside custom_components/, where they break on the WebSocket
+        # rules the same way a standalone card does.
+        plugin = category == "plugin"
+        domains = [] if plugin else iter_manifest_domains(body)
+        findings = scan_sources(
+            () if plugin else iter_component_python(body),
+            iter_javascript(body, skipped, whole_repo=plugin),
+            rules,
+            stats,
+        )
     except tarfile.TarError as err:
         record["status"] = "error"
         record["error"] = f"bad tarball: {err}"[:200]


### PR DESCRIPTION
Closes #21. Built to the five answers in [this comment](https://github.com/Booyaka101/hass-breakage-radar/issues/21#issuecomment-5390315306), with one deliberate change to what I proposed there.

```yaml
- uses: actions/checkout@v7
- uses: Booyaka101/hass-breakage-radar@v1.9.0
```

### The five questions, as built

**Fail or warn** — annotates, does not fail. `fail-on: imminent` gates on what is already released or within `window-days` (90). `fail-on: any` is the strict gate. The CLI keeps defaulting to `any`, because that is what it was already being used as.

**What it reads** — the whole tree at `path`, default `.`.

**How it reports** — annotations *and* a job summary. GitHub displays 10 annotations per level per step and 50 per job, so thirty findings would show as ten and read as though that was all of them. A blocking finding is an `error` and the rest are `warning`s, which also puts them on separate display budgets.

**Fetch or vendor** — `rules: pinned` by default, reading `data/rules.json` from the tag the action resolved to. No network call in anyone else's CI. `rules: index` opts into the published index. Docs say pin an exact tag, since the daily crawl rewrites that file.

**Marketplace** — needs you; it is a checkbox on the release.

### The change from what I proposed

I said card repos should get a quiet no-op. That was wrong, and `tests/test_check_local.py` is why: the exit-code contract is *"could not check" must never be reported as clean*, and a silent green is exactly that. So instead of working around the gap I closed it.

`check_local.py` now reads a checkout with `custom_components/` as an integration (Python plus any frontend module shipped alongside) and a checkout without one as a Lovelace card repository, scanning its JavaScript wherever it lives and deduplicating `src` against `dist` the way the crawler does. It used to exit 2 on all 748 plugin repos in the catalogue. A card repo whose only file is a minified bundle *still* exits 2, because nothing was analysed and that is not the same as clean.

### On not writing a fourth scan loop

`check_local.py` needed to decide what a repository's Python and JS add up to, which `tools/scan.py` and `custom_components/.../scanner.py` already each decide. Rather than write a third copy I extracted `scan_sources()` into `rules_engine.py`, which is vendored byte-for-byte to both sides, and pointed `scan.py` at it. `VENDOR_DIRECTORIES` moved there too, so the comment in `scanner.py` that says "matches the crawler's VENDOR_MARKERS" is now enforced rather than asserted.

Proved it is a no-op rather than arguing it. Ran the old and new `scan_repo` over 16 tarballs built from every fixture tree plus this repo, both categories for every tree, and compared record and findings JSON byte for byte: **16 cases, 0 mismatches**, with both the `scanned` and `no_custom_components` status branches hit.

Ran difflib over the new functions against the ones they parallel, per the repo's own lesson from 1.7.0. Highest pair among anything I wrote is 23%; `read_python` vs `read_javascript` is 5%, `render_text` vs `render_github` is 6%. The highest pair in the file set is 57%, `match_source` vs `match_js_source`, which is pre-existing and untouched.

**Where I stopped:** `custom_components/breakage_radar/scanner.py` still has its own walk. It carries constraints the other two do not (per-domain caching, file caps, an executor, #34 already deduplicated its two paths), and forcing it through one driver would mean a many-parameter function serving three genuinely different workflows. `ENGINE_VERSION` is deliberately not bumped: the extraction changes no semantics, and bumping it would invalidate the cached scan of all 3 908 crawled repositories for nothing.

### Testing

`321 passed, 3 skipped` locally. 21 tests on `check_local` (up from 8) and a new `tests/test_action.py` that asserts the action cannot drift from the CLI: every flag it passes still exists, its declared defaults are values the CLI accepts, `fail-on` is not a release gate, and no input is interpolated into a shell line.

Those need PyYAML, so it is added to the `dev` extra and to the CI install. Nothing shipped imports it, so `"requirements": []` stays honest.

The action also self-tests in `Validate`: it runs against this repo's own fixtures and asserts clean passes, a card repo is scanned rather than refused, a finding annotates without failing, `fail-on: any` turns the same finding into a failure, and a repo of one minified bundle does not pass. I ran the same five cases locally against the extracted shell step first: exits 0, 0, 1, 0, 2 as intended.

Version bumped to 1.9.0 so the tag the docs reference is the one this ships in. Tagging is yours to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
