### PR TITLE
fix(report): a local clean only speaks for the rules it could run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and `pyproject.toml` versions always agree (enforced by a test).
 
 ## 1.9.0 — 2026-08-24
 
+### A local "clean" only speaks for the rules it could run
+
+`report.py` let a local scan's `clean` verdict beat an index finding whenever
+the scan had run any rules at all. That is right when the local engine looked
+for the rule and did not find it: the installed code is newer than the tag the
+crawler scanned. It is wrong when the engine could not look at all.
+
+An installed integration carries a vendored `rules_engine.py`. `Rule.matchable`
+is `self.match.get("type") in MATCHER_TYPES`, so the day the index ships a
+matcher type an installed copy predates, that copy silently skips the rule,
+finds nothing, reports `clean`, and the index's finding was thrown away. The
+user is told an integration is fine while the index says it breaks in 2027.6.
+This is the false-all-clear class #22 recorded as a trap, and it is why #22
+concluded that narrowing a rule could not afford a new matcher type.
+
+The local scan now reports `rule_ids`, the rules it actually ran, and any index
+finding whose rule is not in that list survives, attributed to the index. A
+domain can now carry a local finding and an index finding at once and is still
+listed once.
+
+This removes the constraint rather than working around it: a new matcher type
+is safe to ship once installs are on this, in either direction.
+
+Found by the #25 audit, which needs a new matcher type to cover the
+`DeprecatedAlias` class of removal and walked straight into it.
+
 ### The scanner runs in an integration author's CI (#21)
 
 Every finding this project produces lands on a *user*, and a user cannot fix an

--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ Everything below is covered by a test.
 | Home Assistant is upgraded past a finding's deadline | the finding stays, reclassified `broken_now`, and Repairs escalates to ERROR |
 | A release label cannot be turned into a date | no `imminent` opinion is formed; the finding is summarised rather than guessed at |
 | The index ships no matchable rules | domains scan `unknown` with a reason — an empty rule set never reads as clean |
+| The index ships a rule this installed engine is too old to run | the local scan reports which rule IDs it ran; any index finding it could not look for survives, attributed to the index. A local `clean` only speaks for the rules it actually ran |
 | An integration directory is renamed or forked | matched by the domain its `manifest.json` declares, not the directory name |
 | Very affected system | `details` caps at 100 entries and sets `details_truncated` |
 

--- a/custom_components/breakage_radar/report.py
+++ b/custom_components/breakage_radar/report.py
@@ -111,6 +111,27 @@ def build_report(
     cards_scanned_locally = (local_card_scan or {}).get("cards", {})
     card_rules_in_play = (local_card_scan or {}).get("rules_matchable", 0)
 
+    def _unchecked(
+        index_findings: list[dict[str, Any]], scan: dict[str, Any] | None
+    ) -> list[dict[str, Any]]:
+        """Index findings the local scan was never able to look for.
+
+        A local "clean" only speaks for the rules the local engine could run.
+        When the index ships a rule whose matcher type this vendored engine
+        predates, the engine silently drops it and reports clean anyway --
+        and without this the index's finding would be discarded, telling the
+        user an integration is fine while the index says it breaks.
+
+        A scan that does not report ``rule_ids`` is from an engine that
+        predates the field; there is nothing to compare against, so it keeps
+        the old behaviour rather than resurrecting every index finding.
+        """
+        ran = (scan or {}).get("rule_ids")
+        if not ran:
+            return []
+        known = set(ran)
+        return [f for f in index_findings if f.get("rule_id") not in known]
+
     by_release: dict[str, list[str]] = {}
     details: list[dict[str, Any]] = []
     affected: list[str] = []
@@ -150,10 +171,12 @@ def build_report(
         kind: str = "integration",
     ) -> None:
         if kind == "card":
-            affected_cards.append(domain)
+            if domain not in affected_cards:
+                affected_cards.append(domain)
             broken_bucket, imminent_bucket = broken_now_cards, imminent_cards
         else:
-            affected.append(domain)
+            if domain not in affected:
+                affected.append(domain)
             broken_bucket, imminent_bucket = broken_now, imminent
         for finding in findings:
             release = str(finding.get("breaks_in", ""))
@@ -235,10 +258,17 @@ def build_report(
         ]
         local = scanned_locally.get(domain)
 
+        unchecked = _unchecked(index_findings, local_scan) if local else []
+
         if local and local.get("status") == "affected":
             _add_details(domain, local.get("findings", []), "local", entry)
+            if unchecked:
+                _add_details(domain, unchecked, "index", entry)
         elif local and local.get("status") == "clean" and rules_in_play > 0:
-            clean.append(domain)
+            if unchecked:
+                _add_details(domain, unchecked, "index", entry)
+            else:
+                clean.append(domain)
         elif index_findings:
             _add_details(domain, index_findings, "index", entry)
         elif entry is not None or domain in clean_domains:
@@ -255,10 +285,17 @@ def build_report(
         ]
         local = cards_scanned_locally.get(card)
 
+        unchecked = _unchecked(index_findings, local_card_scan) if local else []
+
         if local and local.get("status") == "affected":
             _add_details(card, local.get("findings", []), "local", entry, kind="card")
+            if unchecked:
+                _add_details(card, unchecked, "index", entry, kind="card")
         elif local and local.get("status") == "clean" and card_rules_in_play > 0:
-            clean_cards.append(card)
+            if unchecked:
+                _add_details(card, unchecked, "index", entry, kind="card")
+            else:
+                clean_cards.append(card)
         elif index_findings:
             _add_details(card, index_findings, "index", entry, kind="card")
         elif entry is not None or card.lower() in index_clean_cards:

--- a/custom_components/breakage_radar/scanner.py
+++ b/custom_components/breakage_radar/scanner.py
@@ -304,6 +304,11 @@ def scan_installed(
         "skipped_files": totals["skipped_files"],
         "cached_domains": cached_domains,
         "rules_matchable": len(rules),
+        # Which rules this engine could actually run. A "clean" verdict only
+        # speaks for these; report.py keeps an index finding whose rule is not
+        # in here, which is what happens when the index ships a matcher type
+        # this vendored engine predates.
+        "rule_ids": sorted(rule.id for rule in rules),
         "rules_fingerprint": fingerprint,
         "engine_version": ENGINE_VERSION,
     }
@@ -457,6 +462,7 @@ def scan_cards(
         **totals,
         "cached_cards": cached_cards,
         "rules_matchable": len(rules),
+        "rule_ids": sorted(rule.id for rule in rules),
         "rules_fingerprint": fingerprint,
         "engine_version": ENGINE_VERSION,
     }

--- a/tests/test_local_merge.py
+++ b/tests/test_local_merge.py
@@ -223,6 +223,132 @@ def test_no_matchers_and_no_index_entry_is_unknown_with_a_reason(
 
 
 # --------------------------------------------------------------------------- #
+# a local clean only speaks for the rules the local engine could run
+# --------------------------------------------------------------------------- #
+
+
+def _unknown_matcher_index(index: dict) -> dict:
+    """The index gains a rule whose matcher type this engine predates.
+
+    Exactly what an install one version behind sees the day a new matcher
+    type ships: Rule.matchable is False for it, so the engine cannot look for
+    it and cannot have an opinion about it.
+    """
+    index["rules"].append(
+        {
+            "id": "from-the-future",
+            "breaks_in": "2027.6",
+            "message": "Imported from the deprecated path.",
+            "source": "https://developers.home-assistant.io/blog/",
+            "confidence": "high",
+            "matchable": True,
+            "match": {
+                "type": "matcher_type_this_engine_does_not_have",
+                "modules": ["homeassistant.components.device_tracker.config_entry"],
+                "names": ["TrackerEntity"],
+            },
+        }
+    )
+    return index
+
+
+def test_a_clean_local_scan_cannot_bury_a_rule_it_could_not_run(
+    tmp_path, fixtures_dir, sample_index
+):
+    """The #22 trap. Without this the user is told the integration is fine
+    while the index says it breaks in 2027.6."""
+    sample_index = _unknown_matcher_index(sample_index)
+    entry = sample_index["integrations"][0]
+    entry["domain"] = entry["domains"][0] = "lookalike_tracker"
+    entry["findings"] = [
+        {
+            "rule_id": "from-the-future",
+            "breaks_in": "2027.6",
+            "file": "custom_components/lookalike_tracker/device_tracker.py",
+            "line": 3,
+            "confidence": "high",
+        }
+    ]
+    components = _install(tmp_path, fixtures_dir, "false_positive", "lookalike_tracker")
+    local = _scan(components, sample_index)
+
+    assert local["domains"]["lookalike_tracker"]["status"] == "clean"
+    assert "from-the-future" not in local["rule_ids"]
+
+    report = build_report(sample_index, {"lookalike_tracker": "0.1.0"}, local)
+    assert report["clean_domains"] == []
+    assert report["affected_domains"] == ["lookalike_tracker"]
+    assert [d["rule_id"] for d in report["details"]] == ["from-the-future"]
+    assert report["details"][0]["source"] == "index"
+
+
+def test_a_clean_local_scan_still_beats_a_rule_it_did_run(
+    tmp_path, fixtures_dir, sample_index
+):
+    """The behaviour that must not regress: the installed bytes are newer
+    than the scanned tag, so local clean wins for rules the engine ran."""
+    entry = sample_index["integrations"][0]
+    entry["domain"] = entry["domains"][0] = "lookalike_tracker"
+    entry["findings"][0]["file"] = "custom_components/lookalike_tracker/device_tracker.py"
+    components = _install(tmp_path, fixtures_dir, "false_positive", "lookalike_tracker")
+    local = _scan(components, sample_index)
+
+    assert "legacy-device-tracker-platform" in local["rule_ids"]
+    report = build_report(sample_index, {"lookalike_tracker": "0.1.0"}, local)
+    assert report["clean_domains"] == ["lookalike_tracker"]
+    assert report["affected_domains"] == []
+
+
+def test_a_local_finding_and_an_unrunnable_rule_are_both_reported(
+    tmp_path, fixtures_dir, sample_index
+):
+    sample_index = _unknown_matcher_index(sample_index)
+    sample_index["integrations"][0]["findings"].append(
+        {
+            "rule_id": "from-the-future",
+            "breaks_in": "2027.6",
+            "file": "custom_components/fixture_tracker/device_tracker.py",
+            "line": 3,
+            "confidence": "high",
+        }
+    )
+    components = _install(tmp_path, fixtures_dir, "true_positive", "fixture_tracker")
+    local = _scan(components, sample_index)
+    report = build_report(sample_index, {"fixture_tracker": "0.1.0"}, local)
+
+    assert report["affected_domains"] == ["fixture_tracker"]  # listed once
+    assert sorted(d["rule_id"] for d in report["details"]) == [
+        "from-the-future",
+        "legacy-device-tracker-platform",
+    ]
+    assert {d["source"] for d in report["details"]} == {"index", "local"}
+
+
+def test_a_scan_from_an_engine_without_rule_ids_keeps_the_old_behaviour(
+    tmp_path, fixtures_dir, sample_index
+):
+    """Nothing to compare against is not a licence to resurrect the index."""
+    sample_index = _unknown_matcher_index(sample_index)
+    entry = sample_index["integrations"][0]
+    entry["domain"] = entry["domains"][0] = "lookalike_tracker"
+    entry["findings"] = [
+        {
+            "rule_id": "from-the-future",
+            "breaks_in": "2027.6",
+            "file": "custom_components/lookalike_tracker/device_tracker.py",
+            "line": 3,
+            "confidence": "high",
+        }
+    ]
+    components = _install(tmp_path, fixtures_dir, "false_positive", "lookalike_tracker")
+    local = _scan(components, sample_index)
+    local.pop("rule_ids")
+
+    report = build_report(sample_index, {"lookalike_tracker": "0.1.0"}, local)
+    assert report["clean_domains"] == ["lookalike_tracker"]
+
+
+# --------------------------------------------------------------------------- #
 # v1.1.1 regressions: a passed deadline must get MORE visible, never less
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Prerequisite for the #25 fix, and a real bug on its own.

### The bug

`report.py` had this:

```python
elif local and local.get("status") == "clean" and rules_in_play > 0:
    clean.append(domain)
```

A local `clean` beats an index finding whenever the scan ran *any* rules. That is correct when the engine looked for the rule and found nothing: the installed code is newer than the tag the crawler scanned, which is the whole point of scanning locally.

It is wrong when the engine could not look.

`Rule.matchable` is `self.match.get("type") in MATCHER_TYPES` (`rules_engine.py:84`), and the local scanner only runs matchable rules. So the day the index ships a matcher type an installed copy predates, that copy skips the rule, finds nothing, reports `clean`, and **the index's finding is thrown away**. The user is told the integration is fine while the index says it breaks in 2027.6.

This is exactly the class #22 recorded as a trap and concluded was a hard blocker on narrowing any rule that matches today. #17 got away with a new matcher type only because `device-entry-config-entries` shipped `matchable: false`, so the crawler produced no index finding for it and there was nothing to bury.

### The fix

The local scan now reports `rule_ids`, the rules it actually ran. `report.py` keeps any index finding whose `rule_id` is not in that list, attributed to the index. A domain can now carry a local finding and an index finding at once, and `_add_details` is idempotent per domain so it is still listed once.

A scan payload with no `rule_ids` is from an engine that predates the field. There is nothing to compare against, so it keeps the old behaviour rather than resurrecting every index finding, which would be the opposite failure.

This removes the constraint rather than working around it. Once installs are on this, a new matcher type is safe in either direction, including the narrowing case #22 had to rule out.

### How I found it

The #25 audit. I ran 60 affected integrations in a real Home Assistant container and diffed its deprecation log against the scanner — [full writeup on the issue](https://github.com/Booyaka101/hass-breakage-radar/issues/25#issuecomment-5390676511). The one real gap it found is a whole deprecation mechanism (`DeprecatedAlias` / `DeprecatedConstant`, 12 declarations, all future), and covering it needs a matcher that reads `ImportFrom`, which is a new matcher type. Went to check #22's rule of thumb before writing it and found that "widening can afford a new type" is not actually true while this line stands: the crawler *does* produce index findings for a new matchable rule, and every existing install would bury them.

So this lands first. The extractor and the `import_from` matcher are a separate change, and should not merge until installs have had this.

### Testing

`325 passed, 3 skipped`. Four new tests in `test_local_merge.py`, all built on an index carrying a rule with a matcher type the engine does not have, which is what an install one version behind actually sees:

- a clean local scan cannot bury a rule it could not run (the bug)
- a clean local scan still beats a rule it *did* run (the behaviour that must not regress)
- a local finding and an unrunnable rule are both reported, domain listed once
- a scan payload without `rule_ids` keeps the old behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)
