### PR TITLE
feat(rules): read core's DeprecatedAlias removals, and match the import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ and `pyproject.toml` versions always agree (enforced by a test).
 
 ## 1.9.0 — 2026-08-24
 
+### Core's other way of announcing a removal is now read (#25)
+
+The rule extractor read `report_usage(..., breaks_in_ha_version=)` and nothing
+else. Core has a second mechanism with no `breaks_in_ha_version` anywhere in
+it:
+
+```python
+_DEPRECATED_TrackerEntity = DeprecatedAlias(
+    _TrackerEntity, "homeassistant.components.device_tracker.TrackerEntity", "2027.6"
+)
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+```
+
+The warning fires on the *import*. The rule set had never seen any of it.
+
+Found by running it. 60 affected integrations in a real Home Assistant
+container, with a fabricated config entry each so the code actually loads, and
+the resulting deprecation log diffed against the scanner. 9 of 11 observations
+already matched a finding. Both misses were this.
+
+* **12 new rules**, every one carrying a future release: 5 in 2027.6
+  (`TrackerEntity`, `ScannerEntity`, `BaseTrackerEntity`,
+  `TrackerEntityDescription`, `SourceType` from
+  `device_tracker.config_entry`) and 7 in 2027.8 (the `CONCENTRATION_*`
+  constants from `homeassistant.const`).
+* **A tenth matcher type, `import_from`**, keyed on the deprecating module
+  rather than the symbol. That distinction is the whole rule: `colota` and
+  `comma_ai` import `TrackerEntity` from the *replacement* path, which is the
+  fix, and Home Assistant logged nothing for them. Matching the name alone
+  would have flagged correct code.
+* **`high` confidence.** A named import from an exact module has no receiver
+  to infer and nothing to collide with, so the 18-character gate that protects
+  auto-derived call matchers does not apply.
+* On the 61-integration audit sample this is **13 findings across 7
+  integrations**, and it catches exactly the two Home Assistant warned about.
+
+`ENGINE_VERSION` goes to 7. The new rules change `rules_hash` anyway, so the
+crawl re-scans the catalogue either way; the bump keeps the engine's identity
+honest about it.
+
 ### A local "clean" only speaks for the rules it could run
 
 `report.py` let a local scan's `clean` verdict beat an index finding whenever

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ under **Download diagnostics** on the integration's page.
 Findings come from two sources, and every `findings` entry says which:
 
 * `source: local` — the integration parsed the **installed bytes** in your own
-  `custom_components/` directory with the same nine AST matchers the crawler
+  `custom_components/` directory with the same ten AST matchers the crawler
   uses. Forks, renamed copies and integrations installed outside HACS get a real
   verdict this way, and there is no version skew: the scanned version *is* the
   installed version.
@@ -405,6 +405,15 @@ a matcher only when it names something specific enough:
 Auto-derived symbols must be at least 18 characters and survive a denylist. Everything
 else is published for the board but never claims a repository is affected.
 
+The same pass also reads core's *other* removal mechanism, which has nothing to do with
+`report_usage`. A module declares
+`_DEPRECATED_TrackerEntity = DeprecatedAlias(_TrackerEntity, "homeassistant.components.device_tracker.TrackerEntity", "2027.6")`
+and hands its `__getattr__` to `check_if_deprecated_constant`, so the warning fires on
+the *import*. Those become `import_from` rules at `high` confidence: a named import from
+an exact module has no receiver to infer, so the 18-character gate does not apply. They
+are keyed on the deprecating module, never the symbol alone, because the same name
+imported from the replacement path is the fix rather than the problem.
+
 **2. Hand-curated (`origin: manual`, `data/manual_rules.json`).** Removals announced in
 prose with no `report_usage` call behind them — the legacy device tracker platform API,
 the device registry single-config-entry changes, the device tracker property removals.
@@ -451,6 +460,7 @@ an implausible fraction of the catalogue is visible rather than quietly taxing e
 | `call_kwarg` | a call to one of `names` passing any keyword in `kwargs` |
 | `call_missing_kwarg` | a call to one of `names` *not* passing `kwarg` |
 | `call_hass_argument` | a call to one of `names` that passes `hass` — for `@deprecated_hass_argument`, where the *argument* is deprecated, not the function |
+| `import_from` | `from <module in modules> import <name in names>` — for core's other removal mechanism, `_DEPRECATED_X = DeprecatedAlias(...)` behind a module `__getattr__`, where the import itself is what breaks. The module is the whole rule: the same name imported from the replacement path is the fix |
 | `js` | an anchored `token` in `.js`/`.ts`/`.mjs` source, comments stripped, only in files that reference the WebSocket API. Built for the device registry WebSocket deprecations, which break Lovelace cards rather than Python integrations |
 
 Any matcher can be narrowed with `files` (exact basenames); `attr` matchers can also

--- a/custom_components/breakage_radar/rules_engine.py
+++ b/custom_components/breakage_radar/rules_engine.py
@@ -4,7 +4,7 @@ A *rule* says "this piece of Python stops working in Home Assistant release X".
 A *matcher* is the machine-checkable half of a rule.  :func:`match_source` runs
 every matcher over one parsed file and yields findings.
 
-Nine matcher types cover every deprecation Breakage Radar currently ships:
+Ten matcher types cover every deprecation Breakage Radar currently ships:
 
 ``moduledef``          a module-level ``def``/``async def`` with one of ``names``
 ``classbase``          a ``class`` whose base list mentions one of ``bases``
@@ -19,6 +19,9 @@ Nine matcher types cover every deprecation Breakage Radar currently ships:
 ``call_hass_argument`` a call to one of ``names`` that passes ``hass`` (first
                        positional or keyword) -- for ``@deprecated_hass_argument``,
                        where the *argument* is deprecated, not the function
+``import_from``        ``from <module in modules> import <name in names>`` --
+                       for ``_DEPRECATED_X = DeprecatedAlias(...)``, where the
+                       import itself is what breaks and the module is the rule
 ``js``                 an anchored ``token`` in JavaScript/TypeScript source --
                        for the device-registry WebSocket API, which breaks
                        Lovelace cards rather than Python integrations. Handled
@@ -57,6 +60,7 @@ MATCHER_TYPES = frozenset(
         "call_kwarg",
         "call_missing_kwarg",
         "call_hass_argument",
+        "import_from",
         "js",
     }
 )
@@ -64,7 +68,7 @@ MATCHER_TYPES = frozenset(
 #: Bumped whenever matching semantics change. It is folded into the crawl's
 #: rules hash, so an engine change forces a rescan instead of leaving stale
 #: findings that the current engine would no longer produce.
-ENGINE_VERSION = 6
+ENGINE_VERSION = 7
 
 VERSION_RE = re.compile(r"^\d{4}\.\d+(?:\.\d+)?$")
 
@@ -423,6 +427,29 @@ def _match_attr_access(
             and isinstance(node.ctx, ast.Load)
         ):
             yield node.lineno, node.attr
+
+
+def _match_import_from(
+    matcher: dict[str, Any], tree: ast.Module, imports: dict[str, str]
+) -> Iterator[tuple[int, str]]:
+    """``from <deprecating module> import <name>``.
+
+    Core's second removal mechanism, ``_DEPRECATED_X = DeprecatedAlias(...)``
+    behind a module ``__getattr__``, fires on the import itself. The module is
+    the whole rule: the same name imported from the replacement path is the
+    fix, so matching on the name alone would flag correct code. A relative
+    import cannot name the deprecating module, so it is never a match.
+    """
+    modules = set(matcher.get("modules", ()))
+    names = set(matcher.get("names", ()))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.level or node.module is None:
+            continue
+        if node.module not in modules:
+            continue
+        for alias in node.names:
+            if alias.name in names:
+                yield node.lineno, f"{node.module}.{alias.name}"
 
 
 def _annotation_resolves(
@@ -1014,6 +1041,7 @@ _DISPATCH = {
     "call_kwarg": _match_call_kwarg,
     "call_missing_kwarg": _match_call_missing_kwarg,
     "call_hass_argument": _match_call_hass_argument,
+    "import_from": _match_import_from,
 }
 
 

--- a/tests/test_deprecated_imports.py
+++ b/tests/test_deprecated_imports.py
@@ -1,0 +1,199 @@
+"""Core's second removal mechanism: ``_DEPRECATED_X = DeprecatedAlias(...)``.
+
+Found by the #25 audit. A real Home Assistant container warned that `leafspy`
+imports `TrackerEntity` from the deprecated path, and no rule covered it,
+because the extractor only ever read ``report_usage(breaks_in_ha_version=)``.
+
+The declarations quoted here are verbatim from home-assistant/core dev at the
+version `data/rules.json` was built from.
+"""
+
+from __future__ import annotations
+
+from tools.extract_rules import build_rules, extract_deprecated_constants
+from tools.rules_engine import Rule, ScanStats, match_source
+
+CONFIG_ENTRY_PY = b'''
+from functools import partial
+
+from homeassistant.helpers.deprecation import (
+    DeprecatedAlias,
+    check_if_deprecated_constant,
+)
+
+_DEPRECATED_TrackerEntity = DeprecatedAlias(
+    _TrackerEntity, "homeassistant.components.device_tracker.TrackerEntity", "2027.6"
+)
+_DEPRECATED_ScannerEntity = DeprecatedAlias(
+    _ScannerEntity, "homeassistant.components.device_tracker.ScannerEntity", "2027.6"
+)
+
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+'''
+
+CONST_PY = b'''
+from homeassistant.helpers.deprecation import DeprecatedConstant, DeprecatedConstantEnum
+
+_DEPRECATED_CONCENTRATION_PARTS_PER_MILLION = DeprecatedConstantEnum(
+    UnitOfConcentration.PARTS_PER_MILLION, "2027.8"
+)
+_DEPRECATED_CONCENTRATION_PARTS_PER_CUBIC_METER = DeprecatedConstant(
+    "p/m3", "CONCENTRATION_PARTS_PER_CUBIC_METER", "2027.8"
+)
+'''
+
+
+def _records(path: str, source: bytes) -> list[dict]:
+    return list(extract_deprecated_constants(path, source))
+
+
+# --------------------------------------------------------------------------- #
+# extraction
+# --------------------------------------------------------------------------- #
+
+
+def test_deprecated_aliases_are_extracted_with_their_release():
+    records = _records(
+        "homeassistant/components/device_tracker/config_entry.py", CONFIG_ENTRY_PY
+    )
+    assert [(r["symbol"], r["version"]) for r in records] == [
+        ("TrackerEntity", "2027.6"),
+        ("ScannerEntity", "2027.6"),
+    ]
+    assert records[0]["module"] == "homeassistant.components.device_tracker.config_entry"
+    assert (
+        records[0]["replacement"]
+        == "homeassistant.components.device_tracker.TrackerEntity"
+    )
+
+
+def test_the_release_is_found_whatever_the_argument_count():
+    """DeprecatedConstantEnum takes two arguments, DeprecatedConstant three,
+    and the replacement path is a string too."""
+    records = _records("homeassistant/const.py", CONST_PY)
+    assert [(r["symbol"], r["version"]) for r in records] == [
+        ("CONCENTRATION_PARTS_PER_MILLION", "2027.8"),
+        ("CONCENTRATION_PARTS_PER_CUBIC_METER", "2027.8"),
+    ]
+    assert all(r["module"] == "homeassistant.const" for r in records)
+
+
+def test_a_declaration_with_no_release_label_is_skipped():
+    source = b'_DEPRECATED_Thing = DeprecatedAlias(_Thing, "some.other.Thing")\n'
+    assert _records("homeassistant/thing.py", source) == []
+
+
+def test_only_module_level_declarations_count():
+    source = b'''
+def factory():
+    _DEPRECATED_Nested = DeprecatedAlias(_X, "a.b.C", "2027.6")
+    return _DEPRECATED_Nested
+'''
+    assert _records("homeassistant/thing.py", source) == []
+
+
+def test_ordinary_assignments_are_not_deprecations():
+    source = b'ALIAS = DeprecatedAlias(_X, "a.b.C", "2027.6")\n'
+    assert _records("homeassistant/thing.py", source) == []
+
+
+def test_a_file_the_interpreter_cannot_parse_is_recorded_not_swallowed():
+    unparsed: list[str] = []
+    assert list(
+        extract_deprecated_constants(
+            "homeassistant/broken.py", b"_DEPRECATED_X = (\n", unparsed
+        )
+    ) == []
+    assert unparsed and "broken.py" in unparsed[0]
+
+
+# --------------------------------------------------------------------------- #
+# the rules that come out
+# --------------------------------------------------------------------------- #
+
+
+def test_the_rule_is_an_import_from_matcher_at_high_confidence():
+    records = _records(
+        "homeassistant/components/device_tracker/config_entry.py", CONFIG_ENTRY_PY
+    )
+    rules = {r["id"]: r for r in build_rules(records, "2026.9")}
+    rule = rules["core-import-config-entry-trackerentity"]
+
+    assert rule["kind"] == "import"
+    assert rule["breaks_in"] == "2027.6"
+    # A named import from an exact module: nothing to infer, nothing to confuse.
+    assert rule["confidence"] == "high"
+    assert rule["matchable"] is True
+    assert rule["match"] == {
+        "type": "import_from",
+        "modules": ["homeassistant.components.device_tracker.config_entry"],
+        "names": ["TrackerEntity"],
+    }
+    assert "Import it from homeassistant.components.device_tracker instead" in (
+        rule["message"]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# the matcher
+# --------------------------------------------------------------------------- #
+
+
+def _rule() -> Rule:
+    records = _records(
+        "homeassistant/components/device_tracker/config_entry.py", CONFIG_ENTRY_PY
+    )
+    payload = next(
+        r
+        for r in build_rules(records, "2026.9")
+        if r["id"] == "core-import-config-entry-trackerentity"
+    )
+    return Rule.from_dict(payload)
+
+
+def _hits(source: str) -> list[tuple[str, int]]:
+    findings = match_source("custom_components/x/device_tracker.py", source, [_rule()], ScanStats())
+    return [(f.rule_id, f.line) for f in findings]
+
+
+def test_importing_from_the_deprecated_module_is_a_finding():
+    assert _hits(
+        "from homeassistant.components.device_tracker.config_entry import TrackerEntity\n"
+    ) == [("core-import-config-entry-trackerentity", 1)]
+
+
+def test_the_replacement_path_is_correct_code_and_must_not_match():
+    """`colota` and `comma_ai` in the audit sample import it this way and
+    Home Assistant logged nothing for them."""
+    assert _hits("from homeassistant.components.device_tracker import TrackerEntity\n") == []
+
+
+def test_a_different_name_from_the_deprecated_module_does_not_match():
+    assert _hits(
+        "from homeassistant.components.device_tracker.config_entry import ScannerEntity\n"
+    ) == []
+
+
+def test_an_aliased_import_is_still_the_deprecated_import():
+    assert _hits(
+        "from homeassistant.components.device_tracker.config_entry import "
+        "TrackerEntity as TE\n"
+    ) == [("core-import-config-entry-trackerentity", 1)]
+
+
+def test_a_relative_import_cannot_name_the_deprecating_module():
+    assert _hits("from .config_entry import TrackerEntity\n") == []
+
+
+def test_a_same_named_class_of_your_own_is_not_a_finding():
+    assert _hits("from .entities import TrackerEntity\n\nclass TrackerEntity:\n    pass\n") == []
+
+
+def test_one_import_line_reports_once_per_name():
+    hits = _hits(
+        "from homeassistant.components.device_tracker.config_entry import (\n"
+        "    TrackerEntity,\n"
+        "    ScannerEntity,\n"
+        ")\n"
+    )
+    assert hits == [("core-import-config-entry-trackerentity", 1)]

--- a/tools/extract_rules.py
+++ b/tools/extract_rules.py
@@ -86,6 +86,18 @@ ISSUE_CALLS = frozenset(
     }
 )
 
+#: Core's *other* removal mechanism. A module declares
+#: ``_DEPRECATED_<Name> = DeprecatedAlias(replacement, "new.path", "2027.6")``
+#: and hands its ``__getattr__`` to ``check_if_deprecated_constant``, so the
+#: warning fires on the import rather than on a call. No ``breaks_in_ha_version``
+#: keyword is involved anywhere, which is why the ``report_usage`` pass above
+#: has never seen any of it. Found by the #25 log audit.
+DEPRECATED_CONSTANT_CALLS = frozenset(
+    {"DeprecatedAlias", "DeprecatedConstant", "DeprecatedConstantEnum"}
+)
+
+_DEPRECATED_PREFIX = "_DEPRECATED_"
+
 #: Minimum length for an auto-derived symbol to be trusted as a matcher.
 #: Short names like ``async_listen`` collide with everybody's own helpers.
 #: See LESSONS 2026-07-27: a rule written from a spec is a hypothesis.
@@ -341,24 +353,36 @@ def _parent_map(tree: ast.Module) -> dict[ast.AST, ast.AST]:
     return parents
 
 
-def extract_from_source(
-    path: str, source: bytes, unparsed: list[str] | None = None
-) -> Iterator[dict[str, Any]]:
-    """Yield raw call-site records from one core file.
+def _parse_if_interesting(
+    path: str, source: bytes, marker: bytes, unparsed: list[str] | None
+) -> ast.Module | None:
+    """Parse a core file that contains ``marker``, or record why not.
 
     Home Assistant's ``dev`` branch tracks the newest CPython syntax, so an
     older interpreter cannot parse every core file (2026.9 dev uses PEP 758
     unparenthesized ``except A, B:``, which needs Python 3.14). Rather than
     pretend, every unparseable file is recorded and reported in ``rules.json``.
+    Both extraction passes look at the same files, so a file that fails for
+    both is recorded once.
     """
-    if b"breaks_in_ha_version" not in source:
-        return
+    if marker not in source:
+        return None
     try:
-        tree = ast.parse(source, filename=path)
+        return ast.parse(source, filename=path)
     except (SyntaxError, ValueError) as err:
         LOGGER.warning("skipping %s: %s", path, err)
-        if unparsed is not None:
-            unparsed.append(f"{path}: {err}")
+        entry = f"{path}: {err}"
+        if unparsed is not None and entry not in unparsed:
+            unparsed.append(entry)
+        return None
+
+
+def extract_from_source(
+    path: str, source: bytes, unparsed: list[str] | None = None
+) -> Iterator[dict[str, Any]]:
+    """Yield raw call-site records from one core file."""
+    tree = _parse_if_interesting(path, source, b"breaks_in_ha_version", unparsed)
+    if tree is None:
         return
 
     parents = _parent_map(tree)
@@ -395,6 +419,93 @@ def extract_from_source(
         }
 
 
+def extract_deprecated_constants(
+    path: str, source: bytes, unparsed: list[str] | None = None
+) -> Iterator[dict[str, Any]]:
+    """Yield one record per ``_DEPRECATED_X = DeprecatedAlias(...)`` declaration.
+
+    The release is whichever string argument looks like a release label, not a
+    fixed position: ``DeprecatedConstantEnum`` takes two arguments and
+    ``DeprecatedAlias`` three, and the replacement path is a string too.
+    """
+    tree = _parse_if_interesting(
+        path, source, _DEPRECATED_PREFIX.encode(), unparsed
+    )
+    if tree is None:
+        return
+
+    module = module_of(path)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        target = next(
+            (
+                t.id
+                for t in node.targets
+                if isinstance(t, ast.Name) and t.id.startswith(_DEPRECATED_PREFIX)
+            ),
+            None,
+        )
+        if target is None:
+            continue
+        func = node.value.func
+        callee = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if callee not in DEPRECATED_CONSTANT_CALLS:
+            continue
+        literals = [
+            arg.value
+            for arg in node.value.args
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+        ]
+        version = next((v for v in reversed(literals) if VERSION_RE.match(v)), None)
+        if not version:
+            LOGGER.debug("%s:%d: %s carries no release label", path, node.lineno, target)
+            continue
+        replacement = next((v for v in literals if v != version), "")
+        yield {
+            "callee": callee,
+            "version": version,
+            "symbol": target[len(_DEPRECATED_PREFIX) :],
+            "module": module,
+            "replacement": replacement,
+            "what": "",
+            "enclosing": "",
+            "path": path,
+            "line": node.lineno,
+        }
+
+
+def _import_rule(record: dict[str, Any], release: str) -> dict[str, Any]:
+    """The rule for one deprecated import, as ``build_rules`` wants it."""
+    symbol = record["symbol"]
+    module = record["module"]
+    replacement = record["replacement"]
+    tail = module.rsplit(".", 1)[-1]
+    advice = (
+        f" Import it from {replacement.rsplit('.', 1)[0]} instead."
+        if replacement
+        else ""
+    )
+    return {
+        "id": f"core-import-{_slug(tail)}-{_slug(symbol)}"[:90],
+        "symbol": symbol,
+        "message": (
+            f"{symbol} imported from {module} is deprecated and is removed in "
+            f"Home Assistant {release}.{advice}"
+        ),
+        # A named import from an exact module: there is no receiver to infer
+        # and nothing to confuse it with, so the length gate that protects
+        # call matchers does not apply here.
+        "confidence": "high",
+        "match": {
+            "type": "import_from",
+            "modules": [module],
+            "names": [symbol],
+        },
+        "replacement": replacement,
+    }
+
+
 def build_rules(records: list[dict[str, Any]], current: str) -> list[dict[str, Any]]:
     """Collapse raw call sites into deduplicated, published rules."""
     by_id: dict[str, dict[str, Any]] = {}
@@ -406,22 +517,31 @@ def build_rules(records: list[dict[str, Any]], current: str) -> list[dict[str, A
             LOGGER.debug("skipping non-release version %r", version)
             continue
 
-        matcher = (
-            derive_matcher(
-                callee, record["what"], record["enclosing"], record["path"]
-            )
-            if callee in API_DEPRECATION_CALLS
-            else None
-        )
-        symbol = _symbol_for(callee, record["what"], record["enclosing"], matcher)
-        kind = _kind_for(callee, matcher)
         release = normalise_version(version)
+        imported = _import_rule(record, release) if callee in DEPRECATED_CONSTANT_CALLS else None
 
-        if callee in ISSUE_CALLS:
-            rule_id = f"core-issue-{_slug(record['enclosing'] or record['path'])}-{release}"
+        if imported:
+            matcher = imported["match"]
+            symbol = imported["symbol"]
+            kind = "import"
+            rule_id = imported["id"]
         else:
-            rule_id = f"core-{kind}-{_slug(symbol)}"
-        rule_id = rule_id[:90]
+            matcher = (
+                derive_matcher(
+                    callee, record["what"], record["enclosing"], record["path"]
+                )
+                if callee in API_DEPRECATION_CALLS
+                else None
+            )
+            symbol = _symbol_for(callee, record["what"], record["enclosing"], matcher)
+            kind = _kind_for(callee, matcher)
+            if callee in ISSUE_CALLS:
+                rule_id = (
+                    f"core-issue-{_slug(record['enclosing'] or record['path'])}-{release}"
+                )
+            else:
+                rule_id = f"core-{kind}-{_slug(symbol)}"
+            rule_id = rule_id[:90]
 
         existing = by_id.get(rule_id)
         if existing:
@@ -435,14 +555,19 @@ def build_rules(records: list[dict[str, Any]], current: str) -> list[dict[str, A
             id=rule_id,
             kind=kind,
             symbol=symbol,
-            message=record["what"] or _message_for(callee, symbol, release),
+            message=(
+                imported["message"]
+                if imported
+                else record["what"] or _message_for(callee, symbol, release)
+            ),
             breaks_in=release,
             source=f"homeassistant/{record['path'].split('homeassistant/', 1)[-1]}:{record['line']}"
             if record["path"].startswith("homeassistant/")
             else f"{record['path']}:{record['line']}",
             origin="core-ast",
-            confidence="medium",
+            confidence=imported["confidence"] if imported else "medium",
             match=matcher,
+            replacement=imported["replacement"] if imported else None,
         )
         payload = rule.to_dict()
         payload["expired"] = not is_future(release, current)
@@ -507,10 +632,22 @@ def main(argv: list[str] | None = None) -> int:
     records: list[dict[str, Any]] = []
     unparsed: list[str] = []
     files = 0
+    imports = 0
     for path, source in iter_core_python(tarball):
         files += 1
         records.extend(extract_from_source(path, source, unparsed))
-    LOGGER.info("scanned %d core files, %d deprecation call sites", files, len(records))
+        # Core announces removals two ways. Reading only report_usage() missed
+        # the DeprecatedAlias class entirely until the #25 log audit found a
+        # real integration warned about one.
+        found = list(extract_deprecated_constants(path, source, unparsed))
+        imports += len(found)
+        records.extend(found)
+    LOGGER.info(
+        "scanned %d core files, %d deprecation call sites, %d deprecated import(s)",
+        files,
+        len(records) - imports,
+        imports,
+    )
     if unparsed:
         LOGGER.warning(
             "%d core file(s) could not be parsed by Python %d.%d - rules defined in "

--- a/tools/rules_engine.py
+++ b/tools/rules_engine.py
@@ -4,7 +4,7 @@ A *rule* says "this piece of Python stops working in Home Assistant release X".
 A *matcher* is the machine-checkable half of a rule.  :func:`match_source` runs
 every matcher over one parsed file and yields findings.
 
-Nine matcher types cover every deprecation Breakage Radar currently ships:
+Ten matcher types cover every deprecation Breakage Radar currently ships:
 
 ``moduledef``          a module-level ``def``/``async def`` with one of ``names``
 ``classbase``          a ``class`` whose base list mentions one of ``bases``
@@ -19,6 +19,9 @@ Nine matcher types cover every deprecation Breakage Radar currently ships:
 ``call_hass_argument`` a call to one of ``names`` that passes ``hass`` (first
                        positional or keyword) -- for ``@deprecated_hass_argument``,
                        where the *argument* is deprecated, not the function
+``import_from``        ``from <module in modules> import <name in names>`` --
+                       for ``_DEPRECATED_X = DeprecatedAlias(...)``, where the
+                       import itself is what breaks and the module is the rule
 ``js``                 an anchored ``token`` in JavaScript/TypeScript source --
                        for the device-registry WebSocket API, which breaks
                        Lovelace cards rather than Python integrations. Handled
@@ -57,6 +60,7 @@ MATCHER_TYPES = frozenset(
         "call_kwarg",
         "call_missing_kwarg",
         "call_hass_argument",
+        "import_from",
         "js",
     }
 )
@@ -64,7 +68,7 @@ MATCHER_TYPES = frozenset(
 #: Bumped whenever matching semantics change. It is folded into the crawl's
 #: rules hash, so an engine change forces a rescan instead of leaving stale
 #: findings that the current engine would no longer produce.
-ENGINE_VERSION = 6
+ENGINE_VERSION = 7
 
 VERSION_RE = re.compile(r"^\d{4}\.\d+(?:\.\d+)?$")
 
@@ -423,6 +427,29 @@ def _match_attr_access(
             and isinstance(node.ctx, ast.Load)
         ):
             yield node.lineno, node.attr
+
+
+def _match_import_from(
+    matcher: dict[str, Any], tree: ast.Module, imports: dict[str, str]
+) -> Iterator[tuple[int, str]]:
+    """``from <deprecating module> import <name>``.
+
+    Core's second removal mechanism, ``_DEPRECATED_X = DeprecatedAlias(...)``
+    behind a module ``__getattr__``, fires on the import itself. The module is
+    the whole rule: the same name imported from the replacement path is the
+    fix, so matching on the name alone would flag correct code. A relative
+    import cannot name the deprecating module, so it is never a match.
+    """
+    modules = set(matcher.get("modules", ()))
+    names = set(matcher.get("names", ()))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.level or node.module is None:
+            continue
+        if node.module not in modules:
+            continue
+        for alias in node.names:
+            if alias.name in names:
+                yield node.lineno, f"{node.module}.{alias.name}"
 
 
 def _annotation_resolves(
@@ -1014,6 +1041,7 @@ _DISPATCH = {
     "call_kwarg": _match_call_kwarg,
     "call_missing_kwarg": _match_call_missing_kwarg,
     "call_hass_argument": _match_call_hass_argument,
+    "import_from": _match_import_from,
 }
 
 


### PR DESCRIPTION
Closes #25. **Stacked on #38 and must not merge before it** — see Sequencing.

### What the audit found

Ran the audit #25 asked for. 60 affected integrations installed at the exact ref the crawl scanned, with a fabricated config entry each so Home Assistant actually imports and sets them up, then diffed its deprecation log against the scanner. [Full writeup on the issue.](https://github.com/Booyaka101/hass-breakage-radar/issues/25#issuecomment-5390676511)

11 deprecation observations, **9 already matched a finding**. Both misses were the same thing:

```
The deprecated alias TrackerEntity was used from leafspy. It will be removed in
HA Core 2027.6. Use homeassistant.components.device_tracker.TrackerEntity instead
```

Core announces removals two ways. `extract_rules.py` only ever read one:

```python
_DEPRECATED_TrackerEntity = DeprecatedAlias(
    _TrackerEntity, "homeassistant.components.device_tracker.TrackerEntity", "2027.6"
)
__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
```

No `breaks_in_ha_version` anywhere in it, and the warning fires on the *import*.

### What this adds

**12 rules**, every one carrying a future release: 5 in 2027.6 (`TrackerEntity`, `ScannerEntity`, `BaseTrackerEntity`, `TrackerEntityDescription`, `SourceType` from `device_tracker.config_entry`) and 7 in 2027.8 (the `CONCENTRATION_*` constants from `homeassistant.const`). That is every `_DEPRECATED_*` declaration in the core tarball.

**A tenth matcher type, `import_from`**, keyed on the deprecating module rather than the symbol. That distinction is the entire rule and the audit is what proves it: `colota` and `comma_ai` also import `TrackerEntity`, but from the *replacement* path, and Home Assistant logged nothing for them. A rule matching the name alone would flag correct code as broken.

**`high` confidence**, not the usual `medium`. A named import from an exact module has no receiver to infer and nothing to collide with, so the 18-character trust gate that protects auto-derived call matchers does not apply here. Documented next to the code.

### Verification

Ran the new rule set back over the audit sample:

- 13 findings across 7 of 61 integrations
- **catches exactly the two Home Assistant warned about**, `leafspy` and `up_4014_tracker`
- `colota` and `comma_ai` stay clean, as they should

Proved the extractor change is additive rather than arguing it: ran the pre-change `extract_rules.py` and the new one over the same core tarball. **The 114 existing rules are byte-identical and the unparsed list is identical.** Only the 12 import rules are new.

14 new tests in `tests/test_deprecated_imports.py`, quoting the declarations verbatim from core. The extraction side covers all three constructs, the release found whatever the argument count, a declaration with no release label, a nested declaration, an ordinary assignment, and an unparseable file. The matcher side covers the deprecated path, the replacement path staying clean, a different name, `import X as Y`, a relative import, and a same-named class of your own.

`339 passed, 3 skipped`.

### Sequencing, which matters here

**Do not merge this before #38.**

Adding a matcher type means every installed copy of the integration on 1.8.0 or earlier cannot run these rules. `Rule.matchable` is `match.type in MATCHER_TYPES`, so those copies skip the rule, find nothing, report the domain `clean`, and — on the current `report.py` — that clean discards the index finding. Users would be told `leafspy` is fine while the index says it breaks in 2027.6.

That is the trap #22 recorded, and checking it before writing this is how I found that #22's rule of thumb ("widening can afford a new matcher type") is not quite right: the crawler *does* produce index findings for a new matchable rule, so there is something to bury. #38 makes a local `clean` speak only for the rules it actually ran, which fixes the class.

Even with #38 merged, installs that have not updated will not detect these locally. They will still get them from the index, which is the correct fallback and the reason #38 comes first.

### One more thing

`ENGINE_VERSION` 6 → 7. The new rules change `rules_hash` regardless, so the crawl re-scans the catalogue either way; the bump keeps the engine's identity honest. `data/rules.json` is deliberately not committed — the daily crawl regenerates it and `tools/rules_changed.py` stages it only when a rule actually changed, which is the arrangement #18 put in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
