### PR TITLE
ci: flag pull requests whose checks GitHub is skipping

### DIFF
--- a/.github/workflows/pr-health.yml
+++ b/.github/workflows/pr-health.yml
@@ -1,0 +1,35 @@
+name: PR health
+
+# A conflicted pull request gets its checks skipped rather than failed, so the
+# pull request page shows no checks at all. Nothing inside the repository can
+# report that, because the workflow that would report it is the one being
+# skipped. This runs from the default branch instead.
+on:
+  schedule:
+    # Just after the daily crawl (03:17 UTC), which is what usually causes it.
+    - cron: "40 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: pr-health
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: Label pull requests whose checks are being skipped
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python tools/pr_health.py --repo "$GITHUB_REPOSITORY" -v

--- a/README.md
+++ b/README.md
@@ -367,6 +367,33 @@ Real finds from that crawl, each hand-verified against the repository's own sour
 revisits repositories that actually changed. `--limit` caps a run; least-recently-scanned
 repositories go first, so coverage rotates on its own.
 
+### The crawl conflicts with open pull requests, and that hides checks
+
+The crawl commits `data/rules.json`, `docs/` and `state/` daily. A branch that touches
+any of them conflicts within hours, and **GitHub cannot build `refs/pull/N/merge` for a
+conflicted pull request, so it skips that pull request's checks entirely.** They do not
+fail, they never run, and the page shows no checks rather than a red one. It reads like a
+branch nobody pushed to.
+
+Two things address it, because the cause cannot be removed entirely:
+
+* `tools/rules_changed.py` keeps `data/rules.json` out of the commit when only its
+  provenance stamps moved, which was the commonest trigger.
+* `tools/pr_health.py`, run daily by `.github/workflows/pr-health.yml` just after the
+  crawl, labels any open pull request GitHub reports as `CONFLICTING` and explains once
+  what the missing checks mean. It runs from the default branch, because a workflow
+  inside a skipped pull request cannot report on itself. `UNKNOWN` mergeability is left
+  alone rather than guessed at, in either direction.
+
+If a board PR conflicts, take `main`'s crawl output and regenerate rather than resolving
+`docs/index.json` by hand:
+
+```bash
+git rebase origin/main
+git checkout origin/main -- docs/index.json docs/index.html docs/feed.xml
+python tools/build_index.py
+```
+
 ### Which Python
 
 Home Assistant's `dev` branch tracks the newest CPython syntax. As of core 2026.9 dev

--- a/tests/test_pr_health.py
+++ b/tests/test_pr_health.py
@@ -1,0 +1,214 @@
+"""The conflicted-PR watcher.
+
+The thing it guards against is an *absence*: GitHub skips a conflicted pull
+request's checks rather than failing them, so the page shows no checks at all.
+The decision logic is what matters here, and it is pure.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools import pr_health
+from tools.pr_health import LABEL, MARKER, plan
+
+
+def _pr(number: int, mergeable: str, *, labelled: bool = False, explained: bool = False):
+    return {
+        "number": number,
+        "title": f"pr {number}",
+        "mergeable": mergeable,
+        "labels": [{"name": LABEL}] if labelled else [],
+        "explained": explained,
+    }
+
+
+def test_a_conflicted_pull_request_is_labelled_and_told_why():
+    assert plan([_pr(1, "CONFLICTING")]) == [
+        {"number": 1, "action": "add", "comment": True}
+    ]
+
+
+def test_a_mergeable_pull_request_is_left_alone():
+    assert plan([_pr(1, "MERGEABLE")]) == []
+
+
+def test_the_label_comes_off_once_it_is_mergeable_again():
+    assert plan([_pr(1, "MERGEABLE", labelled=True)]) == [
+        {"number": 1, "action": "remove", "comment": False}
+    ]
+
+
+def test_a_still_conflicted_pull_request_is_not_nagged_twice():
+    assert plan([_pr(1, "CONFLICTING", labelled=True)]) == []
+
+
+def test_the_explanation_is_not_repeated_when_it_conflicts_again():
+    """Labelled, cleared, conflicted again: the label is the signal."""
+    assert plan([_pr(1, "CONFLICTING", explained=True)]) == [
+        {"number": 1, "action": "add", "comment": False}
+    ]
+
+
+def test_uncomputed_mergeability_is_not_a_guess_in_either_direction():
+    """UNKNOWN is neither conflicted nor mergeable. Acting on it would either
+    label a clean branch or clear a real warning."""
+    assert plan([_pr(1, "UNKNOWN")]) == []
+    assert plan([_pr(1, "UNKNOWN", labelled=True)]) == []
+
+
+def test_a_missing_mergeable_field_is_treated_as_unknown():
+    assert plan([{"number": 1, "labels": [{"name": LABEL}]}]) == []
+
+
+def test_several_pull_requests_are_planned_independently():
+    actions = plan(
+        [
+            _pr(1, "CONFLICTING"),
+            _pr(2, "MERGEABLE", labelled=True),
+            _pr(3, "MERGEABLE"),
+            _pr(4, "UNKNOWN"),
+        ]
+    )
+    assert [(a["number"], a["action"]) for a in actions] == [(1, "add"), (2, "remove")]
+
+
+# --------------------------------------------------------------------------- #
+# the gh layer, with gh stubbed out
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    """Record every gh invocation and answer from a scripted table."""
+    seen: list[list[str]] = []
+    answers: dict[str, str] = {}
+
+    def fake(args, *, check=True):
+        seen.append(args)
+        for key, value in answers.items():
+            if key in " ".join(args):
+                return value
+        return ""
+
+    monkeypatch.setattr(pr_health, "_gh", fake)
+    monkeypatch.setattr(pr_health, "_sleep", lambda _seconds: None)
+    return seen, answers
+
+
+# --------------------------------------------------------------------------- #
+# lazy mergeability, which would otherwise make the whole check a no-op
+# --------------------------------------------------------------------------- #
+
+
+def test_an_unknown_is_re_asked_until_github_answers(calls):
+    """`gh pr list` routinely reports UNKNOWN for a PR GitHub has not looked at.
+    Taking that at face value means this tool never fires at all."""
+    seen, answers = calls
+    answers["pr view"] = json.dumps({"mergeable": "CONFLICTING"})
+    pull = _pr(1, "UNKNOWN")
+    pr_health.resolve_mergeable("acme/thing", pull)
+
+    assert pull["mergeable"] == "CONFLICTING"
+    assert len([a for a in seen if "pr view" in " ".join(a)]) == 1
+
+
+def test_a_known_state_is_not_re_asked(calls):
+    seen, _ = calls
+    pull = _pr(1, "MERGEABLE")
+    pr_health.resolve_mergeable("acme/thing", pull)
+    assert seen == []
+
+
+def test_it_gives_up_rather_than_asking_forever(calls):
+    seen, answers = calls
+    answers["pr view"] = json.dumps({"mergeable": "UNKNOWN"})
+    pull = _pr(1, "UNKNOWN")
+    pr_health.resolve_mergeable("acme/thing", pull)
+
+    assert pull["mergeable"] == "UNKNOWN"
+    assert len([a for a in seen if "pr view" in " ".join(a)]) == 3
+
+
+def test_a_failed_lookup_leaves_it_unknown_rather_than_guessing(calls):
+    seen, answers = calls  # no answer scripted, so gh returns ""
+    pull = _pr(1, "UNKNOWN")
+    pr_health.resolve_mergeable("acme/thing", pull)
+    assert pull["mergeable"] == "UNKNOWN"
+    assert plan([pull]) == []
+
+
+def test_a_listed_unknown_becomes_a_real_action(calls):
+    """End to end through fetch_pulls: list says UNKNOWN, view says CONFLICTING,
+    and the pull request gets labelled."""
+    seen, answers = calls
+    answers["pr list"] = json.dumps([_pr(1, "UNKNOWN")])
+    answers["pr view"] = json.dumps({"mergeable": "CONFLICTING"})
+    pulls = pr_health.fetch_pulls("acme/thing")
+    assert plan(pulls) == [{"number": 1, "action": "add", "comment": True}]
+
+
+def test_fetch_only_asks_for_comments_on_an_unlabelled_conflict(calls):
+    seen, answers = calls
+    answers["pr list"] = json.dumps(
+        [
+            _pr(1, "CONFLICTING"),
+            _pr(2, "CONFLICTING", labelled=True),
+            _pr(3, "MERGEABLE"),
+        ]
+    )
+    pulls = pr_health.fetch_pulls("acme/thing")
+
+    comment_lookups = [a for a in seen if "comments" in " ".join(a)]
+    assert len(comment_lookups) == 1
+    assert "issues/1/comments" in " ".join(comment_lookups[0])
+    assert pulls[0]["explained"] is False
+
+
+def test_an_existing_marker_means_it_was_already_explained(calls):
+    seen, answers = calls
+    answers["pr list"] = json.dumps([_pr(1, "CONFLICTING")])
+    answers["comments"] = f"some other comment\n{MARKER}\nbody"
+    pulls = pr_health.fetch_pulls("acme/thing")
+    assert pulls[0]["explained"] is True
+
+
+def test_apply_labels_then_comments(calls):
+    seen, _ = calls
+    pr_health.apply("acme/thing", [{"number": 7, "action": "add", "comment": True}])
+    joined = [" ".join(a) for a in seen]
+    assert any("--add-label conflicted" in c for c in joined)
+    assert any(c.startswith("pr comment 7") for c in joined)
+
+
+def test_apply_removing_a_label_does_not_comment(calls):
+    seen, _ = calls
+    pr_health.apply("acme/thing", [{"number": 7, "action": "remove", "comment": False}])
+    joined = [" ".join(a) for a in seen]
+    assert any("--remove-label conflicted" in c for c in joined)
+    assert not any(c.startswith("pr comment") for c in joined)
+
+
+def test_dry_run_changes_nothing(calls, capsys):
+    seen, answers = calls
+    answers["pr list"] = json.dumps([_pr(1, "CONFLICTING")])
+    assert pr_health.main(["--repo", "acme/thing", "--dry-run"]) == 0
+    out = capsys.readouterr().out
+    assert "would add conflicted on #1" in out
+    assert not any("pr edit" in " ".join(a) for a in seen)
+
+
+def test_no_actions_means_the_label_is_not_even_created(calls):
+    seen, answers = calls
+    answers["pr list"] = json.dumps([_pr(1, "MERGEABLE")])
+    assert pr_health.main(["--repo", "acme/thing"]) == 0
+    assert not any("label create" in " ".join(a) for a in seen)
+
+
+def test_the_comment_explains_that_checks_are_skipped_not_failed():
+    """The whole point. A generic "please rebase" would bury it."""
+    assert "skips" in pr_health.COMMENT
+    assert "never ran" in pr_health.COMMENT
+    assert MARKER in pr_health.COMMENT

--- a/tools/pr_health.py
+++ b/tools/pr_health.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Flag open pull requests whose checks GitHub is silently skipping.
+
+GitHub cannot build ``refs/pull/N/merge`` for a conflicted pull request, so it
+skips that pull request's ``pull_request`` workflows entirely. The checks do not
+fail, they never run, and the pull request page shows no checks at all rather
+than a red one. It reads like a branch nobody has pushed to yet.
+
+``tools/rules_changed.py`` removed the commonest cause, the daily crawl
+rewriting ``data/rules.json``. It cannot remove the rest: the crawl also
+commits ``docs/`` on every run, and those files genuinely change daily, so any
+branch touching the board conflicts within hours.
+
+No workflow inside the repository can detect this, because the workflow that
+would report it is the one being skipped. So this runs on a schedule against
+the default branch instead, labels what is conflicted, and says once why it
+matters.
+
+Usage::
+
+    python tools/pr_health.py --repo owner/name
+    python tools/pr_health.py --repo owner/name --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools.common import LOGGER, _sleep, setup_logging  # noqa: E402
+
+LABEL = "conflicted"
+LABEL_COLOUR = "d93f0b"
+LABEL_DESCRIPTION = "Conflicts with the base branch, so GitHub is skipping its checks"
+
+#: Left in the thread once, when the label goes on. The marker is how a second
+#: run knows not to say it again.
+MARKER = "<!-- pr-health:conflicted -->"
+
+COMMENT = f"""{MARKER}
+This branch conflicts with `main`, and that is worth more than the usual nudge:
+GitHub cannot build the merge ref for a conflicted pull request, so it **skips
+this pull request's checks entirely**. They are not failing, they never ran, and
+the checks section shows nothing rather than something red.
+
+Almost always the daily crawl, which commits `data/rules.json`, `docs/index.json`,
+`docs/index.html`, `docs/feed.xml` and `state/`. If this branch touches the board,
+rebase onto `main` and regenerate rather than resolving by hand:
+
+```bash
+git fetch origin main
+git rebase origin/main
+git checkout origin/main -- docs/index.json docs/index.html docs/feed.xml
+python tools/build_index.py
+git add -A && git rebase --continue
+```
+
+The label comes off by itself on the next run once this is mergeable.
+"""
+
+
+def _gh(args: list[str], *, check: bool = True) -> str:
+    """Run ``gh`` and return stdout. Split out so tests never shell out."""
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout).strip()
+        if check:
+            raise RuntimeError(f"gh {' '.join(args)} failed: {message}")
+        LOGGER.warning("gh %s failed: %s", " ".join(args), message)
+        return ""
+    return result.stdout
+
+
+def plan(pulls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """What to do about each pull request, as ``{number, action, comment}``.
+
+    Only the two states GitHub is definite about are acted on.
+    ``mergeable: "UNKNOWN"`` means it has not finished computing, which is not
+    the same as either: labelling on it would flag a clean branch, and clearing
+    on it would drop a real warning.
+    """
+    actions: list[dict[str, Any]] = []
+    for pull in pulls:
+        labelled = LABEL in {label.get("name") for label in pull.get("labels") or []}
+        state = pull.get("mergeable")
+        if state == "CONFLICTING" and not labelled:
+            actions.append(
+                {
+                    "number": pull["number"],
+                    "action": "add",
+                    # A pull request already carrying the explanation was
+                    # labelled before, cleared, and has conflicted again. The
+                    # label is the signal; the essay does not need repeating.
+                    "comment": not pull.get("explained", False),
+                }
+            )
+        elif state == "MERGEABLE" and labelled:
+            actions.append({"number": pull["number"], "action": "remove", "comment": False})
+    return actions
+
+
+def resolve_mergeable(repo: str, pull: dict[str, Any]) -> None:
+    """Turn an ``UNKNOWN`` into a real answer where possible.
+
+    GitHub computes mergeability lazily and a list query often gets ``UNKNOWN``
+    back for a pull request it has not looked at recently. Asking for the single
+    pull request starts that computation, so the next answer is real. Without
+    this the whole check quietly does nothing, which is the failure mode it
+    exists to catch.
+    """
+    for _ in range(3):
+        if pull.get("mergeable") != "UNKNOWN":
+            return
+        _sleep(2.0)
+        raw = _gh(
+            ["pr", "view", str(pull["number"]), "--repo", repo, "--json", "mergeable"],
+            check=False,
+        )
+        if not raw:
+            return
+        pull["mergeable"] = json.loads(raw).get("mergeable", "UNKNOWN")
+
+
+def fetch_pulls(repo: str) -> list[dict[str, Any]]:
+    """Open pull requests, each annotated with whether it was already told."""
+    raw = _gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,mergeable,labels",
+        ]
+    )
+    pulls = json.loads(raw or "[]")
+    for pull in pulls:
+        resolve_mergeable(repo, pull)
+    for pull in pulls:
+        if LABEL in {label.get("name") for label in pull.get("labels") or []}:
+            continue
+        if pull.get("mergeable") != "CONFLICTING":
+            continue
+        body = _gh(
+            [
+                "api",
+                f"repos/{repo}/issues/{pull['number']}/comments",
+                "--jq",
+                ".[].body",
+            ],
+            check=False,
+        )
+        pull["explained"] = MARKER in body
+    return pulls
+
+
+def ensure_label(repo: str) -> None:
+    _gh(
+        [
+            "label",
+            "create",
+            LABEL,
+            "--repo",
+            repo,
+            "--color",
+            LABEL_COLOUR,
+            "--description",
+            LABEL_DESCRIPTION,
+            "--force",
+        ],
+        check=False,
+    )
+
+
+def apply(repo: str, actions: list[dict[str, Any]]) -> None:
+    for action in actions:
+        number = str(action["number"])
+        if action["action"] == "add":
+            _gh(["pr", "edit", number, "--repo", repo, "--add-label", LABEL])
+            if action["comment"]:
+                _gh(["pr", "comment", number, "--repo", repo, "--body", COMMENT])
+            LOGGER.warning(
+                "PR #%s conflicts with its base, so its checks are being skipped",
+                number,
+            )
+        else:
+            _gh(["pr", "edit", number, "--repo", repo, "--remove-label", LABEL])
+            LOGGER.info("PR #%s is mergeable again; label removed", number)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="report without labelling anything"
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+    setup_logging(args.verbose)
+
+    pulls = fetch_pulls(args.repo)
+    actions = plan(pulls)
+    LOGGER.info("%d open pull request(s), %d action(s)", len(pulls), len(actions))
+
+    unknown = [p["number"] for p in pulls if p.get("mergeable") == "UNKNOWN"]
+    if unknown:
+        LOGGER.info("mergeability not computed yet for %s; left alone", unknown)
+
+    if args.dry_run:
+        for action in actions:
+            print(f"would {action['action']} {LABEL} on #{action['number']}")
+        return 0
+
+    if actions:
+        ensure_label(args.repo)
+        apply(args.repo, actions)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The loose end I flagged at the end of the last session, now that there is a way to test it.

### The problem

A conflicted pull request cannot have `refs/pull/N/merge` built, so GitHub **skips its `pull_request` workflows**. The checks do not fail. They never run, and the page shows no checks at all rather than a red one. It reads like a branch nobody has pushed to.

#18 removed the commonest cause by keeping `data/rules.json` out of the crawl commit when only provenance moved. It cannot remove the rest: the crawl also commits `docs/` every run and those files genuinely change daily, so any branch touching the board conflicts within hours. PR #36 hit exactly this and produced **no `Validate` run at all** on its first push. I only noticed by looking for the absence of a check, which is not a thing anyone does reliably.

No workflow inside the repository can report this, because the workflow that would report it is the one being skipped. So this runs from the default branch on a schedule, 23 minutes after the crawl.

### What it does

`tools/pr_health.py`, driven by `.github/workflows/pr-health.yml`. Labels any open pull request GitHub reports as `CONFLICTING` with `conflicted`, and comments once explaining that the missing checks are missing rather than passing. The label comes off by itself when the branch is mergeable again.

The comment says what to do about a board conflict, which is take main's crawl output and regenerate rather than resolving `docs/index.json` by hand.

### The bug the tests caught

I first wrote the clear-the-label branch as `state != "CONFLICTING"`, which quietly includes `UNKNOWN` — so a pull request GitHub had not finished computing would have had a real warning removed. `plan()` now only acts on the two states GitHub is definite about.

### The thing that would have made it useless

GitHub computes mergeability lazily, so `mergeable` can come back `UNKNOWN` on a pull request it has not looked at recently, typically right after a push and before the merge commit exists.

Being straight about the evidence, because I nearly overclaimed it. The `UNKNOWN`s I first saw were on *merged* pull requests, where GitHub never computes mergeability at all, so they prove nothing. Checked again against open PR #41: `pr list` and `pr view` both said `MERGEABLE` immediately.

So `resolve_mergeable()` guards a documented behaviour I have not reproduced on an open pull request, not a measured one. It costs one extra call, only when the answer is `UNKNOWN`, and what it guards against is this check being a permanent silent no-op, which is the same class of failure it exists to catch. It re-asks up to three times and gives up as `UNKNOWN` rather than guessing. If you would rather not carry code for an unreproduced case, this is the part to cut.

### Testing

`359 passed, 3 skipped`. 20 tests on `pr_health`, with `gh` stubbed so nothing shells out: the four label transitions, both `UNKNOWN` directions, a missing field, the comment-once marker, dry run, and the lazy-mergeability path including give-up and lookup-failure.

Verified against the live repository: the dry run reports 0 actions with no open pull requests, `gh pr edit --add-label/--remove-label` exist, and the `conflicted` label is created (idempotently, and only when there is something to label).

Once this merges I will dispatch it and confirm it correctly does nothing, then deliberately conflict a throwaway branch to confirm it fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

