### PR TITLE
fix: pin the dotfile walk, and keep the watchdog going after one failure

### DIFF
--- a/tests/test_check_local.py
+++ b/tests/test_check_local.py
@@ -12,7 +12,7 @@ from datetime import date, timedelta
 
 import pytest
 
-from tools.check_local import is_blocking, main
+from tools.check_local import is_blocking, iter_python_files, main
 from tools.rules_engine import Finding
 
 
@@ -136,6 +136,31 @@ def test_an_unreachable_index_cannot_be_checked(fixtures_dir):
         ]
     )
     assert code == 2
+
+
+def test_the_walk_skips_dotted_directories_but_not_dotted_files(tmp_path):
+    """The crawler's tarball reader filters vendored paths and nothing else, so
+    it reads a dotted *file*. Skipping it here would make a local check
+    disagree with the index about the same repository. A dotted *directory* is
+    not source either way.
+
+    Whether a rule then fires on it is the matcher's business: the shipped
+    device-tracker rule constrains `files` to the exact basename
+    `device_tracker.py`, so it would not match `.device_tracker.py`.
+    """
+    domain = tmp_path / "dotty"
+    (domain / ".hidden").mkdir(parents=True)
+    (domain / "node_modules").mkdir()
+    for relative in (
+        "sensor.py",
+        ".generated.py",
+        ".hidden/sensor.py",
+        "node_modules/dep.py",
+    ):
+        (domain / relative).write_text("x = 1\n", encoding="utf-8")
+
+    walked = [relative for _path, relative in iter_python_files(domain)]
+    assert walked == [".generated.py", "sensor.py"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_pr_health.py
+++ b/tests/test_pr_health.py
@@ -207,6 +207,45 @@ def test_no_actions_means_the_label_is_not_even_created(calls):
     assert not any("label create" in " ".join(a) for a in seen)
 
 
+def test_one_failing_pull_request_does_not_drop_the_others(monkeypatch):
+    """The whole point is that a missing signal gets noticed. Bailing on the
+    first failure would lose the rest of the signals."""
+    touched: list[str] = []
+
+    def fake(args, *, check=True):
+        if args[0] == "pr" and args[1] == "edit":
+            number = args[2]
+            if number == "1":
+                raise RuntimeError("no permission")
+            touched.append(number)
+        return ""
+
+    monkeypatch.setattr(pr_health, "_gh", fake)
+    failed = pr_health.apply(
+        "acme/thing",
+        [
+            {"number": 1, "action": "add", "comment": False},
+            {"number": 2, "action": "add", "comment": False},
+            {"number": 3, "action": "remove", "comment": False},
+        ],
+    )
+    assert failed == 1
+    assert touched == ["2", "3"]
+
+
+def test_a_failure_still_makes_the_run_fail(calls, monkeypatch):
+    seen, answers = calls
+    answers["pr list"] = json.dumps([_pr(1, "CONFLICTING")])
+    monkeypatch.setattr(pr_health, "apply", lambda repo, actions: 1)
+    assert pr_health.main(["--repo", "acme/thing"]) == 1
+
+
+def test_a_clean_run_succeeds(calls):
+    seen, answers = calls
+    answers["pr list"] = json.dumps([_pr(1, "CONFLICTING")])
+    assert pr_health.main(["--repo", "acme/thing"]) == 0
+
+
 def test_the_comment_explains_that_checks_are_skipped_not_failed():
     """The whole point. A generic "please rebase" would bury it."""
     assert "skips" in pr_health.COMMENT

--- a/tools/check_local.py
+++ b/tools/check_local.py
@@ -77,7 +77,13 @@ def find_components_dir(target: Path) -> Path | None:
 
 def _walkable(relative: Path) -> bool:
     """Neither vendored nor hidden. A finding in ``node_modules`` is not the
-    repository's to fix, and ``.git`` is not source."""
+    repository's to fix, and ``.git`` is not source.
+
+    Only the directories are judged, not the filename. A dotted *file* like
+    ``.generated.py`` still runs on the user's box, and the crawler reads it
+    too, so skipping it here would make a local check disagree with the index
+    about the same repository.
+    """
     return not any(
         part in _SKIP_DIRECTORIES or part.startswith(".") for part in relative.parts[:-1]
     )

--- a/tools/pr_health.py
+++ b/tools/pr_health.py
@@ -185,20 +185,33 @@ def ensure_label(repo: str) -> None:
     )
 
 
-def apply(repo: str, actions: list[dict[str, Any]]) -> None:
+def apply(repo: str, actions: list[dict[str, Any]]) -> int:
+    """Carry out the plan. Returns how many pull requests could not be updated.
+
+    One pull request failing does not skip the rest: this exists so a missing
+    signal gets noticed, and dropping the other pull requests on the floor
+    because of the first would be the same bug in a different place. The count
+    comes back so the run still fails loudly.
+    """
+    failed = 0
     for action in actions:
         number = str(action["number"])
-        if action["action"] == "add":
-            _gh(["pr", "edit", number, "--repo", repo, "--add-label", LABEL])
-            if action["comment"]:
-                _gh(["pr", "comment", number, "--repo", repo, "--body", COMMENT])
-            LOGGER.warning(
-                "PR #%s conflicts with its base, so its checks are being skipped",
-                number,
-            )
-        else:
-            _gh(["pr", "edit", number, "--repo", repo, "--remove-label", LABEL])
-            LOGGER.info("PR #%s is mergeable again; label removed", number)
+        try:
+            if action["action"] == "add":
+                _gh(["pr", "edit", number, "--repo", repo, "--add-label", LABEL])
+                if action["comment"]:
+                    _gh(["pr", "comment", number, "--repo", repo, "--body", COMMENT])
+                LOGGER.warning(
+                    "PR #%s conflicts with its base, so its checks are being skipped",
+                    number,
+                )
+            else:
+                _gh(["pr", "edit", number, "--repo", repo, "--remove-label", LABEL])
+                LOGGER.info("PR #%s is mergeable again; label removed", number)
+        except RuntimeError as err:
+            failed += 1
+            LOGGER.error("could not update PR #%s: %s", number, err)
+    return failed
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -224,10 +237,13 @@ def main(argv: list[str] | None = None) -> int:
             print(f"would {action['action']} {LABEL} on #{action['number']}")
         return 0
 
-    if actions:
-        ensure_label(args.repo)
-        apply(args.repo, actions)
-    return 0
+    if not actions:
+        return 0
+    ensure_label(args.repo)
+    failed = apply(args.repo, actions)
+    if failed:
+        LOGGER.error("%d of %d pull request(s) could not be updated", failed, len(actions))
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two details from self-reviewing this session's own diff. Neither is user-visible today; both would have been annoying later.

### The dotfile walk was an accident

Extracting `scan_sources()` in #37 also changed `check_local.py`'s walk. It used to skip a path if *any* part started with a dot; it now judges only the directories, so a dotted **file** like `.generated.py` gets read.

That turns out to be the correct behaviour rather than a bug, which is why it went unnoticed: the crawler's `iter_component_python` filters vendored paths and nothing else, so it reads dotted files too. Before the change a local check and the index could disagree about the same repository. After it they agree.

But it was accidental, so it is now pinned by a test and the reason is in the docstring. Dotted *directories* are still skipped, and so is `node_modules`.

Worth noting for the reader, because I got this wrong first: whether a rule then *fires* on such a file is the matcher's business, not the walker's. The shipped device-tracker rule constrains `files` to the exact basename `device_tracker.py`, so it does not match `.device_tracker.py`. My first attempt at this test asserted a finding and failed for that reason; it now tests the walker directly.

### The watchdog gave up too early

`pr_health.apply()` used `_gh(..., check=True)`, so the first pull request it could not label raised and the rest were never touched. For a tool that exists so a *missing signal gets noticed*, silently dropping the other signals is the same bug in a different place.

It now records the failure, carries on, and returns a count so the run still fails loudly rather than reporting partial success as success.

### Testing

`363 passed, 3 skipped`. Three new tests: the walk (dotted dir skipped, dotted file kept, `node_modules` skipped), one pull request failing without dropping the others, and the exit code still being 1 when anything failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)