### PR TITLE
fix(action): fit the Marketplace description limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
+## 1.9.1 — 2026-08-24
+
+Marketplace metadata only. No code change, and the action behaves identically.
+
+`action.yml` shipped a 142-character `description`, and **GitHub Marketplace
+rejects 125 or more**. That limit is only reported on the release page, after
+ticking "Publish this Action to the GitHub Marketplace", so it passed every
+check in CI and blocked the listing at the one point nobody automates. The
+release page validated the name, icon, colour and README fine and failed on
+this alone.
+
+Shortened to 115 characters, keeping both halves of the point (what it finds,
+and which release). `tests/test_action.py` now pins the limit, the nine
+allowed branding colours and the thirteen Feather icons GitHub excludes, so the
+next person to touch this metadata finds out in `pytest` rather than on the
+release page.
+
+Marketplace validates `action.yml` as of the release's **tag**, so the fix
+needed its own tag rather than a correction on `main`. `@v1.9.0` still works as
+an action; it just cannot be listed.
+
 ## 1.9.0 — 2026-08-24
 
 ### Core's other way of announcing a removal is now read (#25)

--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ person who can actually fix a finding:
 
 ```yaml
 - uses: actions/checkout@v7
-- uses: Booyaka101/hass-breakage-radar@v1.9.0
+- uses: Booyaka101/hass-breakage-radar@v1.9.1
 ```
 
 It annotates the exact line and writes a job summary, and by default it does **not**

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,9 @@
 name: "Home Assistant Breakage Radar"
+# GitHub Marketplace rejects a description of 125 characters or more, and the
+# release page only says so once you tick the publish box. Pinned by a test.
 description: >-
-  Find Home Assistant APIs your custom integration or Lovelace card uses that
-  are already scheduled for removal, and which release removes them.
+  Finds Home Assistant APIs scheduled for removal in your custom integration
+  or Lovelace card, and names the release.
 author: "Booyaka101"
 
 branding:

--- a/custom_components/breakage_radar/manifest.json
+++ b/custom_components/breakage_radar/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/Booyaka101/hass-breakage-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.9.0"
+  "version": "1.9.1"
 }

--- a/guides/for-integration-authors.md
+++ b/guides/for-integration-authors.md
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: Booyaka101/hass-breakage-radar@v1.9.0
+      - uses: Booyaka101/hass-breakage-radar@v1.9.1
 ```
 
 That is the whole thing. It works unchanged on a card repository.
@@ -129,7 +129,7 @@ workflow file, and then it is not there to warn you about the one landing next
 month either. When you want a gate, ask for one:
 
 ```yaml
-      - uses: Booyaka101/hass-breakage-radar@v1.9.0
+      - uses: Booyaka101/hass-breakage-radar@v1.9.1
         with:
           fail-on: imminent    # already released, or within window-days
           window-days: "90"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-breakage-radar"
-version = "1.9.0"
+version = "1.9.1"
 description = "Find out which of your Home Assistant custom integrations stop working, and in which future release."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -76,3 +76,57 @@ def test_the_action_declares_every_input_it_uses(action, scan_step):
 
 def test_it_is_a_composite_action_with_no_container_pull(action):
     assert action["runs"]["using"] == "composite"
+
+
+# --------------------------------------------------------------------------- #
+# GitHub Marketplace metadata limits
+#
+# These are only reported on the release page, after ticking the publish box,
+# and a failure there blocks the listing rather than the build. v1.9.0 shipped
+# a 142-character description and could not be published.
+# --------------------------------------------------------------------------- #
+
+#: Marketplace rejects a description of 125 characters or more.
+MAX_DESCRIPTION = 124
+
+#: Feather icons GitHub excludes from action branding, plus their nine colours.
+OMITTED_ICONS = frozenset(
+    {
+        "coffee", "columns", "divide-circle", "divide-square", "divide",
+        "frown", "hexagon", "key", "meh", "mouse-pointer", "smile", "tool",
+        "x-octagon",
+    }
+)
+BRANDING_COLOURS = frozenset(
+    {"white", "black", "yellow", "blue", "green", "orange", "red", "purple", "gray-dark"}
+)
+
+
+def test_the_description_fits_marketplace(action):
+    description = action["description"]
+    assert len(description) <= MAX_DESCRIPTION, (
+        f"{len(description)} characters; Marketplace rejects 125 or more, and "
+        "only tells you on the release page"
+    )
+
+
+def test_the_description_still_says_what_it_finds_and_when(action):
+    """Trimming it to fit must not cost the two halves of the point."""
+    description = action["description"].lower()
+    assert "home assistant" in description
+    assert "removal" in description or "removed" in description
+    assert "release" in description or "when" in description
+
+
+def test_the_branding_is_one_marketplace_accepts(action):
+    branding = action["branding"]
+    assert branding["color"] in BRANDING_COLOURS
+    assert branding["icon"] not in OMITTED_ICONS
+    # Feather names are lowercase and hyphenated; anything else is a typo that
+    # only surfaces on the release page.
+    assert branding["icon"] == branding["icon"].lower().strip()
+
+
+def test_it_has_a_name_and_an_author(action):
+    assert action["name"].strip()
+    assert action["author"].strip()


### PR DESCRIPTION
v1.9.0 could not be published to Marketplace. The release page rejected it with:

> Your action.yml needs changes before it can be published.
> **Description** — Description must be less than 125 characters.

Mine was 142. Name, icon, colour and README all validated; this was the only failure.

### My miss

I checked this before you tried, reported the branding and the name unclaimed, and said the description was fine. I had only measured its *length* (and printed 142) without ever checking what the limit was. Stating it was within limits was not something I had verified.

### The fix

115 characters, keeping both halves of the point:

> Finds Home Assistant APIs scheduled for removal in your custom integration or Lovelace card, and names the release.

The real fix is the test, because this class of limit is only reported on the release page after ticking the publish box — it passes every CI check and then blocks the listing. `tests/test_action.py` now pins:

- the 125-character description limit
- the nine branding colours GitHub accepts
- the thirteen Feather icons GitHub excludes from action branding
- that the trimmed description still says what it finds *and* when

Verified the new test actually catches it: restored the 142-character description, ran the test, it failed; restored the fix, it passes.

### Why a new tag

Marketplace validates `action.yml` as of the release's **tag**, not the default branch, so a correction on `main` would not make v1.9.0 publishable. `@v1.9.0` still works fine as an action, it just cannot be listed. Docs move to `@v1.9.1`; the 1.9.0 CHANGELOG entry keeps its own reference since it is a record of what shipped.

`367 passed, 3 skipped`.