### PR TITLE
Put the install path in the board header, one click

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Assistant install.
 
 ### Via HACS (custom repository)
 
+[![Open your Home Assistant instance and open this repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Booyaka101&repository=hass-breakage-radar&category=integration)
+
+Or by hand:
+
 1. HACS → ⋮ → **Custom repositories**
 2. URL `https://github.com/Booyaka101/hass-breakage-radar`, category **Integration**
 3. Install **Breakage Radar**, restart Home Assistant

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -6,7 +6,7 @@
     <link>https://booyaka101.github.io/hass-breakage-radar/</link>
     <description>Home Assistant APIs scheduled for removal, and how many HACS custom integrations still use each one.</description>
     <language>en</language>
-    <lastBuildDate>Tue, 08 Sep 2026 03:30:49 +0000</lastBuildDate>
+    <lastBuildDate>Tue, 08 Sep 2026 13:45:09 +0000</lastBuildDate>
     <atom:link href="https://booyaka101.github.io/hass-breakage-radar/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Home Assistant 2027.9 - 1 September 2027</title>

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,6 +66,7 @@ footer { max-width:1180px; margin:0 auto; padding:0 20px 50px; color:var(--muted
   text-transform:uppercase; letter-spacing:.05em; }
 .hero { margin:-8px 0 0; font-size:16px; }
 .hero b { color:var(--warn); font-size:18px; }
+.cta { margin:14px 0 0; max-width:70ch; }
 .bucket-h { font-size:22px; letter-spacing:-.01em; margin:38px 0 16px;
   padding-bottom:8px; border-bottom:1px solid var(--line); }
 details.bucket { margin:38px 0 34px; }
@@ -86,6 +87,11 @@ details.bucket[open] > summary { margin-bottom:16px; }
   or simulated.</p>
   <div class="stats"><div class="stat"><b>916</b><span>affected integrations</span></div><div class="stat"><b>6</b><span>affected cards</span></div><div class="stat"><b>2504</b><span>findings</span></div><div class="stat"><b>4009</b><span>repos scanned</span></div><div class="stat"><b>4009</b><span>in HACS catalogue</span></div><div class="stat"><b>527</b><span>minified bundles skipped</span></div><div class="stat"><b>63</b><span>active rules</span></div><div class="stat"><b>60</b><span>removals with no detector</span></div><div class="stat"><b>3</b><span>markers too vague to match</span></div><div class="stat"><b>2026.9</b><span>latest Home Assistant</span></div></div>
   <p class="hero"><b>107</b> integrations break within the next 90 days</p>
+  <p class="cta">This page is the whole catalogue. To see only what is installed on
+  your own box, with a Repairs notice as each deadline nears,
+  <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=Booyaka101&amp;repository=hass-breakage-radar&amp;category=integration">add
+  the companion integration to HACS</a>, or read the
+  <a href="https://github.com/Booyaka101/hass-breakage-radar">source and the rules</a>.</p>
 </header>
 <main>
   <div class="controls">
@@ -116,11 +122,10 @@ details.bucket[open] > summary { margin-bottom:16px; }
 </details>
 </main>
 <footer>
-  <p>Index generated <strong>2026-09-08T03:30:49Z</strong> against Home Assistant core
+  <p>Index generated <strong>2026-09-08T13:45:09Z</strong> against Home Assistant core
   <strong>2026.10</strong>. Machine-readable:
   <a href="index.json">index.json</a> (schema 1).</p>
-  <p>Install the companion Home Assistant integration to see only <em>your</em>
-  affected integrations:
+  <p>Source, rules and install steps:
   <a href="https://github.com/Booyaka101/hass-breakage-radar">Booyaka101/hass-breakage-radar</a>.</p>
   <p>A finding is a static-analysis result, not a guarantee of breakage. Rules
   marked <span class="conf-medium">medium</span> can match a same-named symbol

--- a/docs/index.json
+++ b/docs/index.json
@@ -1,6 +1,6 @@
 {
  "schema": 1,
- "generated_utc": "2026-09-08T03:30:49Z",
+ "generated_utc": "2026-09-08T13:45:09Z",
  "index_url": "https://booyaka101.github.io/hass-breakage-radar/index.json",
  "core_version": "2026.10",
  "latest_release": "2026.9",

--- a/tools/build_index.py
+++ b/tools/build_index.py
@@ -379,6 +379,7 @@ footer {{ max-width:1180px; margin:0 auto; padding:0 20px 50px; color:var(--mute
   text-transform:uppercase; letter-spacing:.05em; }}
 .hero {{ margin:-8px 0 0; font-size:16px; }}
 .hero b {{ color:var(--warn); font-size:18px; }}
+.cta {{ margin:14px 0 0; max-width:70ch; }}
 .bucket-h {{ font-size:22px; letter-spacing:-.01em; margin:38px 0 16px;
   padding-bottom:8px; border-bottom:1px solid var(--line); }}
 details.bucket {{ margin:38px 0 34px; }}
@@ -399,6 +400,11 @@ details.bucket[open] > summary {{ margin-bottom:16px; }}
   or simulated.</p>
   <div class="stats">{stats}</div>
   {hero}
+  <p class="cta">This page is the whole catalogue. To see only what is installed on
+  your own box, with a Repairs notice as each deadline nears,
+  <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=Booyaka101&amp;repository=hass-breakage-radar&amp;category=integration">add
+  the companion integration to HACS</a>, or read the
+  <a href="https://github.com/Booyaka101/hass-breakage-radar">source and the rules</a>.</p>
 </header>
 <main>
   <div class="controls">
@@ -421,8 +427,7 @@ details.bucket[open] > summary {{ margin-bottom:16px; }}
   <p>Index generated <strong>{generated}</strong> against Home Assistant core
   <strong>{core}</strong>. Machine-readable:
   <a href="index.json">index.json</a> (schema 1).</p>
-  <p>Install the companion Home Assistant integration to see only <em>your</em>
-  affected integrations:
+  <p>Source, rules and install steps:
   <a href="https://github.com/Booyaka101/hass-breakage-radar">Booyaka101/hass-breakage-radar</a>.</p>
   <p>A finding is a static-analysis result, not a guarantee of breakage. Rules
   marked <span class="conf-medium">medium</span> can match a same-named symbol


### PR DESCRIPTION
The board's only pointer at the companion integration was a footer line, underneath 2,500 findings. Anyone arriving from someone else's link reads whether their integration is doomed and leaves, which matches what the numbers say: the board gets read, Home Assistant analytics still shows the integration at zero installs, and the HACS default listing (hacs/default#9839) has not moved since 8 August with 885 non-draft PRs open ahead of it.

So the action moves above the table:

- Header gets a line under the 90-day hero: what the page is, and that a companion integration reports only what is installed on your own box through Repairs.
- The HACS custom-repository step becomes a My Home Assistant link instead of "three-dot menu, Custom repositories, paste this URL, pick Integration".
- The footer line stops repeating the install pitch and just points at the source.
- README gets the same one-click badge ahead of the manual steps, which stay.

`docs/` is the regenerated artifact; the only content churn is `days_until` ticking over and the generated timestamp. No scan, rule or schema change. 471 tests pass.

Prompted by a wave of third-party coverage the board is not converting: Alex Kvazis posted it to 23.5K Telegram subscribers and an 87.8K-subscriber YouTube channel on 7 September, and FabScene ran an article on 13 August that links the board directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)