### PR TITLE
fix(rules): read the statistics metadata options as mapping keys, not keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to Breakage Radar. Versions follow
 [semver](https://semver.org/); the `custom_components/breakage_radar/manifest.json`
 and `pyproject.toml` versions always agree (enforced by a test).
 
+## 1.13.0 — 2026-09-11
+
+### The statistics metadata rules were reading a key as a keyword
+
+`unit_class` and `mean_type` are keys of the `metadata` mapping that
+`async_import_statistics` and `async_add_external_statistics` take as their
+second argument. Neither function accepts a keyword by those names, so
+`async_import_statistics(hass, metadata, statistics, unit_class="energy")` is
+not code anybody can write. The extractor read core's sentence, "doesn't
+specify unit_class when calling async_import_statistics", as a keyword name
+and built a `call_missing_kwarg` matcher out of it. A keyword that cannot be
+passed is a keyword that is always missing, so the rule fired on every call
+site in the catalogue, the ones that set both keys correctly included.
+
+Two maintainers reported it: ReikanYsora/Helios-Forecast#38 on 12 August, and
+barisdemirdelen/homeassistant-greenchoice#66 on 11 September with the code
+that proves it. Helios-Forecast had already restructured its metadata so that
+a static scanner would see the keys, with a comment saying so, and the board
+flagged it anyway.
+
+Measured against the 206 findings 1.11.0 shipped over 96 integrations, 26
+stand. Of the rest, 103 are call sites where the key or the keyword is
+provably set, and 74 are mappings the scanner cannot read in full, where "not
+visible here" was being reported as "missing". The last 3 are in a file that
+needs core's own Python 3.14 to parse, so the crawler judges them and this
+machine did not.
+
+The new matcher reads the mapping instead of the call. A dict literal, a
+`StatisticMetaData(...)` constructor, or a local or module-level name that
+resolves to one of those is readable, and a key written anywhere in it counts
+as set, value or not, because presence is what core tests for. A mapping
+spread from `**`, built by a helper, mutated through `update()`, subscripted
+with a computed key or handed in as a parameter is not readable, and nothing
+unreadable is ever a finding.
+
+    {"type": "call_missing_arg_key", "names": ["async_import_statistics"],
+     "modules": ["homeassistant.components.recorder.statistics"],
+     "key": "unit_class", "arg": "metadata", "arg_index": 1,
+     "constructors": ["StatisticMetaData"]}
+
+The extractor no longer derives any of this from the prose. It reads the `if`
+the marker sits under: `if "unit_class" not in metadata` is a mapping key, and
+`if new_unit_of_measurement is not UNDEFINED and new_unit_class is UNDEFINED`
+is a real keyword whose check is only armed when a new unit of measurement
+comes with it, which `call_missing_kwarg` now carries as `requires`. Renaming
+a statistic with `async_update_statistics_metadata` and no new unit was never
+a problem and is no longer reported. A guard that fits neither shape produces
+prose with no matcher and shows up in `discarded_markers` as
+`unreadable_guard`.
+
+Taking the target from the enclosing `def` rather than the sentence also fixes
+a rule that was missing entirely. Core's `mean_type` marker inside
+`async_add_external_statistics` says "when calling async_import_statistics",
+its own copy-paste, so both markers folded into one rule and the external
+half was invisible: 16 real findings in the same corpus that 1.11.0 never
+reported. There are now five statistics rules where there were four, and their
+ids changed with their meaning.
+
+`ENGINE_VERSION` is 10, which queues every repository for a rescan.
+
 ## 1.12.0 — 2026-09-07
 
 ### The device registry's containers, where the attribute is fine and the use is not

--- a/README.md
+++ b/README.md
@@ -464,8 +464,18 @@ a matcher only when it names something specific enough:
 
 * `"calls async_device_info_to_link_from_entity, which is deprecated…"` → a `call`
   matcher, pinned to the module that defines it.
-* `"doesn't specify unit_class when calling async_import_statistics"` → a
-  `call_missing_kwarg` matcher.
+* `"doesn't specify unit_class when calling async_import_statistics"` → read off
+  the `if` the marker sits under, not off the sentence. `if "unit_class" not in
+  metadata` is a key of the `metadata` argument, so it becomes a
+  `call_missing_arg_key` matcher; `if new_unit_of_measurement is not UNDEFINED and
+  new_unit_class is UNDEFINED` is a real keyword, and the first half of it becomes
+  `requires`. The prose cannot tell those apart, and reading it as a keyword is what
+  shipped 99 wrong findings in 1.11.0: `unit_class=` is not a keyword
+  `async_import_statistics` accepts at all, so the matcher fired on every caller,
+  correct ones included. The enclosing `def` is also the target, because core's
+  `mean_type` marker inside `async_add_external_statistics` names
+  `async_import_statistics`. A guard neither shape fits is published as prose and
+  recorded in `discarded_markers` as `unreadable_guard`.
 * `"calls `async_listen` which is deprecated"` → a `call` matcher pinned to
   `homeassistant.components.labs.helpers`. `async_listen` is 12 characters and everybody
   has one, so the pin is what makes it a rule: the engine only fires where the file's
@@ -560,7 +570,8 @@ an implausible fraction of the catalogue is visible rather than quietly taxing e
 | `container_use` | a *deprecated use* of a container attribute on a proved registry: subscription, a lookup method, or membership by device id on `registry.devices`. Iterating the very same attribute stays supported |
 | `call` | a call to one of `names` |
 | `call_kwarg` | a call to one of `names` passing any keyword in `kwargs` |
-| `call_missing_kwarg` | a call to one of `names` *not* passing `kwarg` |
+| `call_missing_kwarg` | a call to one of `names` *not* passing `kwarg`, and passing every keyword in `requires` if there is one — core arms some of these checks only when a related keyword is present |
+| `call_missing_arg_key` | a call to one of `names` whose mapping argument (`arg`, `arg_index`) provably does not set `key`. For options core takes inside a `TypedDict` argument rather than as keywords: a dict literal, a `constructors` call, or a local or module-level name that resolves to one. A mapping the file cannot read in full — spread from `**`, built by a helper, mutated through `update()`, handed in as a parameter — is never a finding |
 | `call_hass_argument` | a call to one of `names` that passes `hass` — for `@deprecated_hass_argument`, where the *argument* is deprecated, not the function |
 | `import_from` | `from <module in modules> import <name in names>` — for core's other removal mechanism, `_DEPRECATED_X = DeprecatedAlias(...)` behind a module `__getattr__`, where the import itself is what breaks. The module is the whole rule: the same name imported from the replacement path is the fix |
 | `js` | an anchored `token` in `.js`/`.ts`/`.mjs` source, comments stripped, only in files that reference the WebSocket API. Built for the device registry WebSocket deprecations, which break Lovelace cards rather than Python integrations |

--- a/custom_components/breakage_radar/manifest.json
+++ b/custom_components/breakage_radar/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/Booyaka101/hass-breakage-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.12.0"
+  "version": "1.13.0"
 }

--- a/custom_components/breakage_radar/rules_engine.py
+++ b/custom_components/breakage_radar/rules_engine.py
@@ -4,7 +4,7 @@ A *rule* says "this piece of Python stops working in Home Assistant release X".
 A *matcher* is the machine-checkable half of a rule.  :func:`match_source` runs
 every matcher over one parsed file and yields findings.
 
-Eleven matcher types cover every deprecation Breakage Radar currently ships:
+Twelve matcher types cover every deprecation Breakage Radar currently ships:
 
 ``moduledef``          a module-level ``def``/``async def`` with one of ``names``
 ``classbase``          a ``class`` whose base list mentions one of ``bases``
@@ -19,7 +19,14 @@ Eleven matcher types cover every deprecation Breakage Radar currently ships:
                        iterating the very same container is still supported
 ``call``               a call to one of ``names`` (bare or attribute access)
 ``call_kwarg``         a call to one of ``names`` passing any keyword in ``kwargs``
-``call_missing_kwarg`` a call to one of ``names`` *not* passing keyword ``kwarg``
+``call_missing_kwarg`` a call to one of ``names`` *not* passing keyword ``kwarg``,
+                       optionally only where every keyword in ``requires`` *is*
+                       passed -- core arms some of these checks conditionally
+``call_missing_arg_key``
+                       a call to one of ``names`` whose mapping argument (``arg``,
+                       ``arg_index``) provably does not set ``key``. For options
+                       core takes inside a ``TypedDict`` argument rather than as
+                       keywords, where a missing key is not visible on the call
 ``call_hass_argument`` a call to one of ``names`` that passes ``hass`` (first
                        positional or keyword) -- for ``@deprecated_hass_argument``,
                        where the *argument* is deprecated, not the function
@@ -65,6 +72,7 @@ MATCHER_TYPES = frozenset(
         "call",
         "call_kwarg",
         "call_missing_kwarg",
+        "call_missing_arg_key",
         "call_hass_argument",
         "import_from",
         "js",
@@ -74,7 +82,7 @@ MATCHER_TYPES = frozenset(
 #: Bumped whenever matching semantics change. It is folded into the crawl's
 #: rules hash, so an engine change forces a rescan instead of leaving stale
 #: findings that the current engine would no longer produce.
-ENGINE_VERSION = 9
+ENGINE_VERSION = 10
 
 VERSION_RE = re.compile(r"^\d{4}\.\d+(?:\.\d+)?$")
 
@@ -996,8 +1004,16 @@ def _match_call_kwarg(
 def _match_call_missing_kwarg(
     matcher: dict[str, Any], tree: ast.Module, imports: dict[str, str]
 ) -> Iterator[tuple[int, str]]:
+    """A call that omits a keyword core now requires.
+
+    ``requires`` is the rest of core's own guard.
+    ``async_update_statistics_metadata`` only warns about a missing
+    ``new_unit_class`` when ``new_unit_of_measurement`` is passed too, so a
+    call that passes neither is healthy and has to stay silent.
+    """
     names = set(matcher.get("names", ()))
     kwarg = matcher.get("kwarg")
+    requires = set(matcher.get("requires", ()))
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and _called_name(node) in names:
             if not _module_allowed(matcher, node, _called_name(node), imports):
@@ -1005,8 +1021,202 @@ def _match_call_missing_kwarg(
             # ``**kwargs`` (arg is None) could supply it -- do not guess.
             if any(keyword.arg is None for keyword in node.keywords):
                 continue
-            if not any(keyword.arg == kwarg for keyword in node.keywords):
+            passed = {keyword.arg for keyword in node.keywords}
+            if not requires <= passed:
+                continue
+            if kwarg not in passed:
                 yield node.lineno, f"{_called_name(node)}(no {kwarg})"
+
+
+#: Methods that add keys out of sight of the assignment that built the mapping.
+#: One of these on the name and the file can no longer say what it holds.
+MAPPING_MUTATORS = frozenset({"update", "setdefault", "pop", "popitem", "clear"})
+
+
+def _parents(tree: ast.Module) -> dict[ast.AST, ast.AST]:
+    return {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+
+
+def _enclosing_scope(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> ast.AST | None:
+    """The function or module whose body ``node`` sits in."""
+    current = parents.get(node)
+    while current is not None:
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module)):
+            return current
+        current = parents.get(current)
+    return None
+
+
+def _binds(target: ast.expr, name: str) -> bool:
+    return any(
+        isinstance(node, ast.Name) and node.id == name for node in ast.walk(target)
+    )
+
+
+def _mapping_keys(node: ast.expr, constructors: Collection[str]) -> set[str] | None:
+    """The keys a mapping expression sets, or ``None`` when it cannot be read.
+
+    A key counts as set wherever it is written, whatever the value: core tests
+    for the key itself, so ``{"unit_class": None}`` satisfies it.
+    """
+    if isinstance(node, ast.Dict):
+        keys = set()
+        for key in node.keys:
+            # ``{**base, "unit_class": x}``: ``base`` is not readable here.
+            if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
+                return None
+            keys.add(key.value)
+        return keys
+    if isinstance(node, ast.Call):
+        # The TypedDict's own constructor, ``StatisticMetaData(unit_class=...)``.
+        if _called_name(node) not in constructors or node.args:
+            return None
+        if any(keyword.arg is None for keyword in node.keywords):
+            return None
+        return {keyword.arg for keyword in node.keywords}
+    return None
+
+
+def _keys_bound_in(
+    name: str, scope: ast.AST, constructors: Collection[str]
+) -> tuple[bool, set[str] | None]:
+    """``(bound, keys)`` for ``name`` in ``scope``; ``keys`` is None if unreadable.
+
+    Deliberately flow-insensitive and inclusive: every assignment anywhere in
+    the scope counts, nested scopes included. Over-collecting keys only ever
+    silences a finding, which is the side to be wrong on here. Anything that
+    could set a key out of sight -- a computed subscript, unpacking, a mutator
+    method, the name being a parameter -- reads as unreadable rather than as
+    empty.
+    """
+    if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        arguments = scope.args
+        if name in {
+            arg.arg
+            for arg in (*_all_args(scope), arguments.vararg, arguments.kwarg)
+            if arg is not None
+        }:
+            return True, None
+
+    keys: set[str] = set()
+    bound = False
+    for node in ast.walk(scope):
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    if node.value is None:  # a bare ``x: SomeType`` annotation
+                        return True, None
+                    from_value = _mapping_keys(node.value, constructors)
+                    if from_value is None:
+                        return True, None
+                    keys |= from_value
+                    bound = True
+                elif (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == name
+                ):
+                    if not (
+                        isinstance(target.slice, ast.Constant)
+                        and isinstance(target.slice.value, str)
+                    ):
+                        return True, None
+                    keys.add(target.slice.value)
+                    bound = True
+                elif isinstance(target, (ast.Tuple, ast.List)) and _binds(target, name):
+                    return True, None
+        elif isinstance(node, ast.AugAssign) and _binds(node.target, name):
+            return True, None
+        elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)) and _binds(
+            node.target, name
+        ):
+            return True, None
+        elif isinstance(node, ast.withitem) and node.optional_vars is not None:
+            if _binds(node.optional_vars, name):
+                return True, None
+        elif isinstance(node, (ast.Global, ast.Nonlocal)) and name in node.names:
+            return True, None
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == name
+                and func.attr in MAPPING_MUTATORS
+            ):
+                return True, None
+    return bound, keys
+
+
+def _mapping_argument(node: ast.Call, matcher: dict[str, Any]) -> ast.expr | None:
+    """The mapping this call passes, positionally or by keyword."""
+    index = matcher.get("arg_index")
+    if index is not None and len(node.args) > index:
+        # A ``*args`` ahead of the slot moves whatever lands in it.
+        if any(isinstance(arg, ast.Starred) for arg in node.args[: index + 1]):
+            return None
+        return node.args[index]
+    return next(
+        (k.value for k in node.keywords if k.arg and k.arg == matcher.get("arg")),
+        None,
+    )
+
+
+def _resolve_mapping_name(
+    name: str,
+    node: ast.Call,
+    parents: dict[ast.AST, ast.AST],
+    constructors: Collection[str],
+) -> set[str] | None:
+    """Follow a name to the keys it holds, innermost scope outwards."""
+    scope = _enclosing_scope(node, parents)
+    while scope is not None:
+        bound, keys = _keys_bound_in(name, scope, constructors)
+        if bound:
+            return keys
+        scope = _enclosing_scope(scope, parents)
+    return None
+
+
+def _match_call_missing_arg_key(
+    matcher: dict[str, Any], tree: ast.Module, imports: dict[str, str]
+) -> Iterator[tuple[int, str]]:
+    """A call whose mapping argument provably does not set a required key.
+
+    Core's statistics helpers take their options inside ``metadata``, not as
+    keywords, so ``async_add_external_statistics(hass, metadata, stats)`` can
+    never pass ``unit_class=`` at all. Reading that guard as a keyword shipped
+    99 wrong findings over 96 integrations in 1.11.0 and was reported twice
+    (ReikanYsora/Helios-Forecast#38,
+    barisdemirdelen/homeassistant-greenchoice#66), both on code that sets the
+    key correctly. This one reads the mapping instead, and a mapping it cannot
+    read in full is never a finding.
+    """
+    names = set(matcher.get("names", ()))
+    key = matcher.get("key")
+    constructors = matcher.get("constructors", ())
+    parents: dict[ast.AST, ast.AST] | None = None
+
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and _called_name(node) in names):
+            continue
+        if not _module_allowed(matcher, node, _called_name(node), imports):
+            continue
+        argument = _mapping_argument(node, matcher)
+        if argument is None:
+            continue
+        keys = _mapping_keys(argument, constructors)
+        if keys is None and isinstance(argument, ast.Name):
+            if parents is None:
+                parents = _parents(tree)
+            keys = _resolve_mapping_name(argument.id, node, parents, constructors)
+        if keys is not None and key not in keys:
+            yield node.lineno, f"{_called_name(node)}(no {key})"
 
 
 def _looks_like_hass(node: ast.expr) -> bool:
@@ -1262,6 +1472,7 @@ _DISPATCH = {
     "call": _match_call,
     "call_kwarg": _match_call_kwarg,
     "call_missing_kwarg": _match_call_missing_kwarg,
+    "call_missing_arg_key": _match_call_missing_arg_key,
     "call_hass_argument": _match_call_hass_argument,
     "import_from": _match_import_from,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hass-breakage-radar"
-version = "1.12.0"
+version = "1.13.0"
 description = "Find out which of your Home Assistant custom integrations stop working, and in which future release."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/fixtures/statistics_metadata/false_positive/custom_components/lookalike_statistics/coordinator.py
+++ b/tests/fixtures/statistics_metadata/false_positive/custom_components/lookalike_statistics/coordinator.py
@@ -1,0 +1,149 @@
+"""Fixture: metadata that really does set unit_class and mean_type.
+
+Every shape here is one a real integration writes, and none of them is a
+finding. The literal shapes are the ones 1.11.0 got wrong -- a keyword matcher
+fired on the call, which can never carry ``unit_class=`` at all, so it fired on
+correct code too. The rest are mappings this file cannot read in full, where
+"not visible here" must not be reported as "missing".
+"""
+
+from homeassistant.components.recorder.models import StatisticMetaData
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    async_import_statistics,
+    async_update_statistics_metadata,
+)
+
+DOMAIN = "lookalike_statistics"
+
+#: A module-level template, the way one integration keeps it.
+TEMPLATE = {
+    "has_mean": False,
+    "has_sum": True,
+    "mean_type": 0,
+    "name": "Water",
+    "source": DOMAIN,
+    "statistic_id": f"{DOMAIN}:water",
+    "unit_class": "volume",
+    "unit_of_measurement": "m³",
+}
+
+
+def inline_dict(hass, statistics):
+    """Both keys written in the literal at the call."""
+    async_add_external_statistics(
+        hass,
+        {
+            "has_mean": False,
+            "has_sum": True,
+            "mean_type": 0,
+            "name": "Energy",
+            "source": DOMAIN,
+            "statistic_id": f"{DOMAIN}:energy",
+            "unit_class": "energy",
+            "unit_of_measurement": "kWh",
+        },
+        statistics,
+    )
+
+
+def typed_dict_constructor(hass, statistics):
+    """The TypedDict's own constructor counts as the literal it is."""
+    metadata = StatisticMetaData(
+        has_mean=False,
+        has_sum=True,
+        mean_type=0,
+        name="Gas",
+        source=DOMAIN,
+        statistic_id=f"{DOMAIN}:gas",
+        unit_class="volume",
+        unit_of_measurement="m³",
+    )
+    async_import_statistics(hass, metadata, statistics)
+
+
+def local_name(hass, statistics):
+    """A local built a few lines above the call."""
+    metadata = {
+        "has_mean": False,
+        "has_sum": True,
+        "mean_type": 0,
+        "name": "Cost",
+        "source": DOMAIN,
+        "statistic_id": f"{DOMAIN}:cost",
+        "unit_class": None,
+        "unit_of_measurement": "EUR",
+    }
+    async_add_external_statistics(hass, metadata, statistics)
+
+
+def keys_added_by_subscript(hass, statistics):
+    """Written after the literal, but written where the file can see it."""
+    metadata = {"has_sum": True, "source": DOMAIN, "statistic_id": f"{DOMAIN}:sub"}
+    metadata["mean_type"] = 0
+    metadata["unit_class"] = "energy"
+    async_import_statistics(hass, metadata, statistics)
+
+
+def module_level_template(hass, statistics):
+    """Resolved out of the module scope."""
+    async_add_external_statistics(hass, TEMPLATE, statistics)
+
+
+def spread_from_elsewhere(hass, statistics, base):
+    """``**base`` could carry either key: unreadable, so silent."""
+    async_import_statistics(hass, {**base, "name": "Spread"}, statistics)
+
+
+def built_by_a_helper(hass, statistics):
+    """A helper's return value is not readable here."""
+    async_add_external_statistics(hass, _build_metadata(), statistics)
+
+
+def mutated_through_update(hass, statistics):
+    """``update()`` can add anything."""
+    metadata = {"source": DOMAIN, "statistic_id": f"{DOMAIN}:mutated"}
+    metadata.update(_extra())
+    async_import_statistics(hass, metadata, statistics)
+
+
+def handed_in_as_a_parameter(hass, metadata, statistics):
+    """The caller owns the mapping."""
+    async_add_external_statistics(hass, metadata, statistics)
+
+
+def computed_key(hass, statistics, field):
+    """A computed subscript could be either key."""
+    metadata = {"source": DOMAIN, "statistic_id": f"{DOMAIN}:computed"}
+    metadata[field] = 0
+    async_import_statistics(hass, metadata, statistics)
+
+
+def rename_only(hass):
+    """No new unit, so core's unit_class check is not armed."""
+    async_update_statistics_metadata(
+        hass, f"{DOMAIN}:water", new_statistic_id=f"{DOMAIN}:water_total"
+    )
+
+
+def new_unit_with_its_class(hass):
+    """The new unit and the class that goes with it."""
+    async_update_statistics_metadata(
+        hass,
+        f"{DOMAIN}:water",
+        new_unit_of_measurement="L",
+        new_unit_class="volume",
+    )
+
+
+def keywords_from_elsewhere(hass, changes):
+    """``**changes`` could carry new_unit_class."""
+    async_update_statistics_metadata(hass, f"{DOMAIN}:water", **changes)
+
+
+def _build_metadata():
+    return {"source": DOMAIN, "statistic_id": f"{DOMAIN}:helper"}
+
+
+def _extra():
+    return {"mean_type": 0, "unit_class": "energy"}

--- a/tests/fixtures/statistics_metadata/true_positive/custom_components/fixture_statistics/coordinator.py
+++ b/tests/fixtures/statistics_metadata/true_positive/custom_components/fixture_statistics/coordinator.py
@@ -1,0 +1,50 @@
+"""Fixture: statistics metadata that really is missing the new keys.
+
+Home Assistant 2026.11 requires ``mean_type`` and ``unit_class`` in the
+metadata mapping, and ``new_unit_class`` alongside a new unit of measurement.
+Every call here omits one of them, in the mapping the file can read in full.
+"""
+
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    async_import_statistics,
+    async_update_statistics_metadata,
+)
+
+DOMAIN = "fixture_statistics"
+
+
+def push_external(hass, statistics):
+    """Neither key, inline: two findings on the call."""
+    async_add_external_statistics(
+        hass,
+        {
+            "has_mean": False,
+            "has_sum": True,
+            "name": "Water",
+            "source": DOMAIN,
+            "statistic_id": f"{DOMAIN}:water",
+            "unit_of_measurement": "m³",
+        },
+        statistics,
+    )
+
+
+def push_internal(hass, statistics):
+    """``mean_type`` set, ``unit_class`` forgotten: one finding."""
+    metadata = {
+        "has_sum": True,
+        "mean_type": 0,
+        "name": "Energy",
+        "source": DOMAIN,
+        "statistic_id": "sensor.fixture_energy",
+        "unit_of_measurement": "kWh",
+    }
+    async_import_statistics(hass, metadata, statistics)
+
+
+def rename_the_unit(hass):
+    """A new unit with no unit class: core reports this one."""
+    async_update_statistics_metadata(
+        hass, "sensor.fixture_energy", new_unit_of_measurement="Wh"
+    )

--- a/tests/test_missing_option.py
+++ b/tests/test_missing_option.py
@@ -1,0 +1,327 @@
+"""The 2026.11 statistics metadata rules.
+
+``unit_class`` and ``mean_type`` are keys of the ``metadata`` mapping, not
+keywords, so ``async_import_statistics(hass, metadata, stats)`` can never pass
+``unit_class=`` at all. 1.11.0 read core's prose as a keyword and shipped 99
+wrong findings over 96 integrations; two maintainers reported it
+(ReikanYsora/Helios-Forecast#38,
+barisdemirdelen/homeassistant-greenchoice#66). The matcher now reads the
+mapping, and the extractor reads core's ``if`` rather than its prose.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import scan_fixture_tree
+
+from tools.extract_rules import build_rules, extract_from_source
+from tools.rules_engine import load_rules, match_source
+
+#: The real guards, copied from home-assistant/core ``dev`` at 2026.9. Note
+#: the ``mean_type`` marker inside ``async_add_external_statistics``: its prose
+#: names ``async_import_statistics``, which is core's own copy-paste and is why
+#: a prose-derived rule folded the two functions into one.
+CORE_STATISTICS = b'''
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.frame import report_usage
+from homeassistant.helpers.typing import UNDEFINED, UndefinedType
+
+
+@callback
+def async_update_statistics_metadata(
+    hass: HomeAssistant,
+    statistic_id: str,
+    *,
+    new_statistic_id: str | UndefinedType = UNDEFINED,
+    new_unit_class: str | UndefinedType | None = UNDEFINED,
+    new_unit_of_measurement: str | UndefinedType | None = UNDEFINED,
+    _called_from_ws_api: bool = False,
+) -> None:
+    """Update statistics metadata for a statistic_id."""
+    if new_unit_of_measurement is not UNDEFINED and new_unit_class is UNDEFINED:
+        if not _called_from_ws_api:
+            report_usage(
+                (
+                    "doesn't specify unit_class when calling "
+                    "async_update_statistics_metadata"
+                ),
+                breaks_in_ha_version="2026.11",
+                exclude_integrations={DOMAIN},
+            )
+
+
+@callback
+def async_import_statistics(
+    hass: HomeAssistant,
+    metadata: StatisticMetaData,
+    statistics: Iterable[StatisticData],
+    *,
+    _called_from_ws_api: bool = False,
+) -> None:
+    """Import hourly statistics from an internal source."""
+    if "mean_type" not in metadata and not _called_from_ws_api:
+        report_usage(
+            "doesn't specify mean_type when calling async_import_statistics",
+            breaks_in_ha_version="2026.11",
+            exclude_integrations={DOMAIN},
+        )
+    if "unit_class" not in metadata and not _called_from_ws_api:
+        report_usage(
+            "doesn't specify unit_class when calling async_import_statistics",
+            breaks_in_ha_version="2026.11",
+            exclude_integrations={DOMAIN},
+        )
+
+
+@callback
+def async_add_external_statistics(
+    hass: HomeAssistant,
+    metadata: StatisticMetaData,
+    statistics: Iterable[StatisticData],
+    *,
+    _called_from_ws_api: bool = False,
+) -> None:
+    """Add hourly statistics from an external source."""
+    if "mean_type" not in metadata and not _called_from_ws_api:
+        report_usage(
+            "doesn't specify mean_type when calling async_import_statistics",
+            breaks_in_ha_version="2026.11",
+            exclude_integrations={DOMAIN},
+        )
+    if "unit_class" not in metadata and not _called_from_ws_api:
+        report_usage(
+            "doesn't specify unit_class when calling async_add_external_statistics",
+            breaks_in_ha_version="2026.11",
+            exclude_integrations={DOMAIN},
+        )
+'''
+
+EXTERNAL_MEAN = "core-call-async-add-external-statistics-metadata-without-mean-type"
+EXTERNAL_UNIT = "core-call-async-add-external-statistics-metadata-without-unit-class"
+IMPORT_MEAN = "core-call-async-import-statistics-metadata-without-mean-type"
+IMPORT_UNIT = "core-call-async-import-statistics-metadata-without-unit-class"
+UPDATE_UNIT = "core-call-async-update-statistics-metadata-missing-new-unit-class"
+
+CALLER_HEADER = (
+    "from homeassistant.components.recorder.models import StatisticMetaData\n"
+    "from homeassistant.components.recorder.statistics import (\n"
+    "    async_add_external_statistics,\n"
+    "    async_import_statistics,\n"
+    "    async_update_statistics_metadata,\n"
+    ")\n"
+)
+
+
+@pytest.fixture(scope="module")
+def statistics_payload() -> list[dict]:
+    """The published rules, extracted from the pinned core guards."""
+    records = list(
+        extract_from_source(
+            "homeassistant/components/recorder/statistics.py", CORE_STATISTICS
+        )
+    )
+    return build_rules(records, "2026.10")
+
+
+@pytest.fixture(scope="module")
+def statistics_rules(statistics_payload):
+    return load_rules(statistics_payload)
+
+
+def _findings(body, rules):
+    return [
+        (f.line, f.rule_id)
+        for f in match_source(
+            "custom_components/x/__init__.py", CALLER_HEADER + body, rules
+        )
+    ]
+
+
+def test_the_guard_names_the_function_core_prose_misnames(statistics_payload):
+    """Core's ``mean_type`` prose names the wrong function in one of the two
+    places it appears, so a prose-derived rule covered only one function and
+    claimed the other's call sites were the same rule. Reading the enclosing
+    ``def`` instead produces both, separately."""
+    assert {rule["id"] for rule in statistics_payload} == {
+        EXTERNAL_MEAN,
+        EXTERNAL_UNIT,
+        IMPORT_MEAN,
+        IMPORT_UNIT,
+        UPDATE_UNIT,
+    }
+
+
+def test_a_mapping_key_is_not_derived_as_a_keyword(statistics_payload):
+    rules = {rule["id"]: rule for rule in statistics_payload}
+    assert rules[EXTERNAL_UNIT]["match"] == {
+        "type": "call_missing_arg_key",
+        "names": ["async_add_external_statistics"],
+        "modules": ["homeassistant.components.recorder.statistics"],
+        "key": "unit_class",
+        "arg": "metadata",
+        "arg_index": 1,
+        "constructors": ["StatisticMetaData"],
+    }
+    # This one really is a keyword, and only when a new unit comes with it.
+    assert rules[UPDATE_UNIT]["match"] == {
+        "type": "call_missing_kwarg",
+        "names": ["async_update_statistics_metadata"],
+        "modules": ["homeassistant.components.recorder.statistics"],
+        "kwarg": "new_unit_class",
+        "requires": ["new_unit_of_measurement"],
+    }
+
+
+def test_the_message_says_where_the_option_goes(statistics_payload):
+    """Core's own wording is kept, because that is what the log line says, but
+    it is not the sentence the board leads with: it calls a key a keyword."""
+    rules = {rule["id"]: rule for rule in statistics_payload}
+    assert rules[IMPORT_UNIT]["message"] == (
+        "doesn't set `unit_class` in the `metadata` passed to "
+        "`async_import_statistics`, which is required from Home Assistant "
+        "2026.11. Home Assistant logs it as: doesn't specify unit_class when "
+        "calling async_import_statistics"
+    )
+
+
+def test_correct_metadata_is_never_a_finding(fixtures_dir, statistics_rules):
+    findings = scan_fixture_tree(
+        fixtures_dir / "statistics_metadata" / "false_positive", statistics_rules
+    )
+    assert findings == []
+
+
+def test_missing_options_are_reported(fixtures_dir, statistics_rules):
+    findings = scan_fixture_tree(
+        fixtures_dir / "statistics_metadata" / "true_positive", statistics_rules
+    )
+    assert sorted((f.line, f.rule_id) for f in findings) == [
+        (19, EXTERNAL_MEAN),
+        (19, EXTERNAL_UNIT),
+        (43, IMPORT_UNIT),
+        (48, UPDATE_UNIT),
+    ]
+
+
+def test_the_reported_false_positive_stays_silent(statistics_rules):
+    """barisdemirdelen/homeassistant-greenchoice#66 and
+    ReikanYsora/Helios-Forecast#38, in the shape they were reported in: the
+    keys are declared in the literal, which is exactly what a static scanner
+    can see."""
+    body = (
+        "def import_readings(hass, statistic_id, readings):\n"
+        "    metadata = StatisticMetaData(\n"
+        "        has_mean=False,\n"
+        "        has_sum=True,\n"
+        "        mean_type=0,\n"
+        "        name=None,\n"
+        "        source='recorder',\n"
+        "        statistic_id=statistic_id,\n"
+        "        unit_class='energy',\n"
+        "        unit_of_measurement='kWh',\n"
+        "    )\n"
+        "    async_import_statistics(hass, metadata, readings)\n"
+    )
+    assert _findings(body, statistics_rules) == []
+
+
+@pytest.mark.parametrize(
+    ("mapping", "reported"),
+    [
+        ("{'unit_class': 'energy', 'mean_type': 0}", False),
+        ("{'unit_class': None, 'mean_type': None}", False),  # set is set
+        ("{'mean_type': 0}", True),
+        ("dict(unit_class='energy', mean_type=0)", False),  # unreadable, not empty
+        ("StatisticMetaData(unit_class='energy', mean_type=0)", False),
+        ("StatisticMetaData(mean_type=0)", True),
+        ("StatisticMetaData(**base)", False),
+        ("{**base, 'mean_type': 0}", False),
+        ("build()", False),
+        ("self._metadata", False),
+        ("templates[statistic_id]", False),
+    ],
+)
+def test_only_a_mapping_read_in_full_can_be_reported(
+    mapping, reported, statistics_rules
+):
+    body = (
+        "def push(self, hass, statistic_id, statistics, base, build):\n"
+        f"    async_add_external_statistics(hass, {mapping}, statistics)\n"
+    )
+    hit = [rule_id for _, rule_id in _findings(body, statistics_rules)]
+    assert (EXTERNAL_UNIT in hit) is reported
+
+
+@pytest.mark.parametrize(
+    ("keywords", "reported"),
+    [
+        ("new_statistic_id='sensor.b'", False),  # the check is not armed
+        ("new_unit_of_measurement='Wh'", True),
+        ("new_unit_of_measurement='Wh', new_unit_class='energy'", False),
+        ("new_unit_of_measurement='Wh', new_unit_class=None", False),
+        ("**changes", False),
+    ],
+)
+def test_the_keyword_check_needs_the_keyword_that_arms_it(
+    keywords, reported, statistics_rules
+):
+    body = (
+        "def rename(hass, changes):\n"
+        f"    async_update_statistics_metadata(hass, 'sensor.a', {keywords})\n"
+    )
+    hit = [rule_id for _, rule_id in _findings(body, statistics_rules)]
+    assert (UPDATE_UNIT in hit) is reported
+
+
+def test_the_mapping_is_followed_out_of_the_scope_that_built_it(statistics_rules):
+    """A name is resolved in the function that uses it, then the module. A
+    parameter is not resolved at all: the caller owns what is in it."""
+    resolved = (
+        "TEMPLATE = {'mean_type': 0, 'unit_class': 'energy'}\n"
+        "\n"
+        "def push(hass, statistics):\n"
+        "    async_import_statistics(hass, TEMPLATE, statistics)\n"
+    )
+    assert _findings(resolved, statistics_rules) == []
+
+    given = (
+        "def push(hass, metadata, statistics):\n"
+        "    async_import_statistics(hass, metadata, statistics)\n"
+    )
+    assert _findings(given, statistics_rules) == []
+
+    shadowed = (
+        "TEMPLATE = {'mean_type': 0, 'unit_class': 'energy'}\n"
+        "\n"
+        "def push(hass, statistics):\n"
+        "    TEMPLATE = {'mean_type': 0}\n"
+        "    async_import_statistics(hass, TEMPLATE, statistics)\n"
+    )
+    assert [rule_id for _, rule_id in _findings(shadowed, statistics_rules)] == [
+        IMPORT_UNIT
+    ]
+
+
+def test_an_unreadable_guard_is_published_as_prose_and_discarded():
+    """A "doesn't specify X" marker whose ``if`` cannot be read is not turned
+    into a matcher on the strength of its prose, and the gap is recorded."""
+    source = b'''
+from homeassistant.helpers.frame import report_usage
+
+
+def async_do_something(hass, options):
+    """Do something."""
+    if not _supported(options):
+        report_usage(
+            "doesn't specify unit_class when calling async_do_something",
+            breaks_in_ha_version="2026.11",
+        )
+'''
+    discarded: list[dict] = []
+    records = list(extract_from_source("homeassistant/helpers/thing.py", source))
+    rules = build_rules(records, "2026.10", discarded)
+
+    assert [(d["symbol"], d["reason"]) for d in discarded] == [
+        ("async_do_something", "unreadable_guard")
+    ]
+    assert [rule["matchable"] for rule in rules] == [False]

--- a/tools/extract_rules.py
+++ b/tools/extract_rules.py
@@ -221,6 +221,34 @@ def _message_for(callee: str, symbol: str, release: str) -> str:
     return f"uses `{symbol}`, deprecated and removed in Home Assistant {release}."
 
 
+def _logs_it_as(lead: str, what: str) -> str:
+    """Our own sentence, then core's, which is what the log line will say."""
+    return f"{lead} Home Assistant logs it as: {what}" if what else lead
+
+
+def _missing_option_message(matcher: dict[str, Any], release: str, what: str) -> str:
+    """The message for a missing key or keyword, said in the right terms.
+
+    Core's prose calls both of these a keyword and misnames one of the
+    functions, so the sentence is generated from the guard instead. See
+    :func:`marker_guard`.
+    """
+    target = matcher["names"][0]
+    if matcher["type"] == "call_missing_arg_key":
+        lead = (
+            f"doesn't set `{matcher['key']}` in the `{matcher['arg']}` passed to "
+            f"`{target}`, which is required from Home Assistant {release}."
+        )
+    else:
+        needed = "` and `".join(matcher.get("requires", ()))
+        lead = (
+            f"calls `{target}`{f' with `{needed}`' if needed else ''} but no "
+            f"`{matcher['kwarg']}`, which is required from Home Assistant "
+            f"{release}."
+        )
+    return _logs_it_as(lead, what)
+
+
 def _scoped_message(symbol: str, release: str, what: str) -> str:
     """The message for a scoped rule, naming the base class as well.
 
@@ -233,7 +261,101 @@ def _scoped_message(symbol: str, release: str, what: str) -> str:
         f"defines `{name}` on a subclass of `{base}`, which is deprecated and "
         f"removed in Home Assistant {release}."
     )
-    return f"{lead} Home Assistant logs it as: {what}" if what else lead
+    return _logs_it_as(lead, what)
+
+
+def _annotation_name(annotation: ast.expr | None) -> str:
+    """The bare name of a simple annotation: ``StatisticMetaData``."""
+    if isinstance(annotation, ast.Name):
+        return annotation.id
+    if isinstance(annotation, ast.Attribute):
+        return annotation.attr
+    return ""
+
+
+def _undefined_test(condition: ast.expr, op: type[ast.cmpop]) -> str:
+    """The name in ``x is UNDEFINED`` / ``x is not UNDEFINED``, for that ``op``."""
+    if not (isinstance(condition, ast.Compare) and len(condition.ops) == 1):
+        return ""
+    if not isinstance(condition.ops[0], op):
+        return ""
+    left, right = condition.left, condition.comparators[0]
+    if isinstance(left, ast.Name) and _annotation_name(right) == "UNDEFINED":
+        return left.id
+    return ""
+
+
+def marker_guard(
+    guards: list[ast.expr],
+    func: ast.FunctionDef | ast.AsyncFunctionDef | None,
+) -> dict[str, Any] | None:
+    """What the ``if`` around a "doesn't specify X" marker actually tests.
+
+    The prose says "keyword" even where core means a key of a mapping
+    argument. ``async_import_statistics`` takes its options inside
+    ``metadata``, so ``unit_class=`` is not a keyword it accepts at all, and a
+    keyword matcher for it fired on every caller. The guard tells the two
+    apart:
+
+    ``"unit_class" not in metadata``   a key of that parameter
+    ``new_unit_class is UNDEFINED``    a real keyword, and an ``x is not
+                                       UNDEFINED`` term next to it is a
+                                       precondition for the check being armed
+
+    The enclosing function is the one third-party code calls, and it is more
+    reliable than the prose: core's ``mean_type`` marker inside
+    ``async_add_external_statistics`` names ``async_import_statistics``.
+    """
+    if func is None:
+        return None
+    positional = [*func.args.posonlyargs, *func.args.args]
+    params = {arg.arg: arg for arg in [*positional, *func.args.kwonlyargs]}
+
+    for condition in guards:
+        if not (isinstance(condition, ast.Compare) and len(condition.ops) == 1):
+            continue
+        key, right = condition.left, condition.comparators[0]
+        if not (
+            isinstance(condition.ops[0], ast.NotIn)
+            and isinstance(key, ast.Constant)
+            and isinstance(key.value, str)
+            and isinstance(right, ast.Name)
+            and right.id in params
+        ):
+            continue
+        guard = {
+            "kind": "arg_key",
+            "key": key.value,
+            "arg": right.id,
+            "target": func.name,
+            "constructor": _annotation_name(params[right.id].annotation),
+        }
+        index = next(
+            (i for i, arg in enumerate(positional) if arg.arg == right.id), None
+        )
+        if index is not None:
+            guard["arg_index"] = index
+        return guard
+
+    missing = [
+        name
+        for condition in guards
+        if (name := _undefined_test(condition, ast.Is)) in params
+    ]
+    if not missing:
+        return None
+    return {
+        "kind": "kwarg",
+        "kwarg": missing[0],
+        "requires": sorted(
+            {
+                name
+                for condition in guards
+                if (name := _undefined_test(condition, ast.IsNot)) in params
+            }
+        ),
+        "target": func.name,
+    }
 
 
 def _call_matcher(symbol: str, module: str) -> dict[str, Any]:
@@ -364,6 +486,7 @@ def derive_matcher(
     scope: dict[str, Any] | None = None,
     discarded: list[tuple[str, str]] | None = None,
     params: Collection[str] = (),
+    guard: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     """Turn a human-readable deprecation message into a machine matcher.
 
@@ -386,6 +509,10 @@ def derive_matcher(
     ``params`` is every parameter name declared in the core file the marker
     came from. It is what :func:`_plausible_kwarg` checks a short keyword
     against.
+
+    ``guard`` is :func:`marker_guard` on the ``if`` the marker sits under. A
+    "doesn't specify X" marker is derived from that rather than from its own
+    prose, which does not distinguish a keyword from a mapping key.
     """
     if scope:
         return {
@@ -424,15 +551,32 @@ def derive_matcher(
 
     match = _RE_MISSING_KWARG.search(what)
     if match:
-        kwarg, target = match.group(1), _tail(match.group(2))
-        if _trusted(target, discarded, pinned=bool(module)) and _plausible_kwarg(
-            kwarg, params, discarded
-        ):
-            matcher = _call_matcher(target, module)
-            matcher["type"] = "call_missing_kwarg"
-            matcher["kwarg"] = kwarg
+        if guard is None:
+            # Without the guard there is no telling a keyword from a mapping
+            # key, and guessing keyword was the whole false positive.
+            if discarded is not None:
+                discarded.append((_tail(match.group(2)), "unreadable_guard"))
+            return None
+        target = guard["target"]
+        if not _trusted(target, discarded, pinned=bool(module)):
+            return None
+        matcher = _call_matcher(target, module)
+        if guard["kind"] == "arg_key":
+            matcher["type"] = "call_missing_arg_key"
+            matcher["key"] = guard["key"]
+            matcher["arg"] = guard["arg"]
+            if "arg_index" in guard:
+                matcher["arg_index"] = guard["arg_index"]
+            if guard["constructor"]:
+                matcher["constructors"] = [guard["constructor"]]
             return matcher
-        return None
+        if not _plausible_kwarg(guard["kwarg"], params, discarded):
+            return None
+        matcher["type"] = "call_missing_kwarg"
+        matcher["kwarg"] = guard["kwarg"]
+        if guard["requires"]:
+            matcher["requires"] = guard["requires"]
+        return matcher
 
     match = _RE_CALL_WITH.search(what)
     if match:
@@ -466,6 +610,7 @@ def _kind_for(callee: str, matcher: dict[str, Any] | None) -> str:
         "call": "call",
         "call_kwarg": "call",
         "call_missing_kwarg": "call",
+        "call_missing_arg_key": "call",
         "call_hass_argument": "call",
         "attr": "attr",
         "attr_access": "attr",
@@ -489,6 +634,8 @@ def _symbol_for(callee: str, what: str, enclosing: str, matcher) -> str:
                 return f"{base}({kwargs[0]}=...)"
             if matcher["type"] == "call_missing_kwarg" and kwargs:
                 return f"{base}(missing {kwargs[0]})"
+            if matcher["type"] == "call_missing_arg_key":
+                return f"{base}({matcher['arg']} without {matcher['key']})"
             if matcher["type"] == "call_hass_argument":
                 return f"{base}(hass, ...)"
             return base
@@ -603,12 +750,30 @@ def extract_from_source(
             continue
 
         chain: list[ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef] = []
+        guards: list[ast.expr] = []
+        child: ast.AST = node
         current: ast.AST | None = parents.get(node)
         while current is not None:
             if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
                 chain.append(current)
-            current = parents.get(current)
+            elif isinstance(current, ast.If) and child in current.body:
+                # Only the taken branch: an ``else`` says the opposite.
+                guards.extend(
+                    current.test.values
+                    if isinstance(current.test, ast.BoolOp)
+                    and isinstance(current.test.op, ast.And)
+                    else [current.test]
+                )
+            child, current = current, parents.get(current)
         chain.reverse()
+        enclosing_func = next(
+            (
+                frame
+                for frame in reversed(chain)
+                if isinstance(frame, (ast.FunctionDef, ast.AsyncFunctionDef))
+            ),
+            None,
+        )
 
         record = {
             "callee": callee,
@@ -618,6 +783,7 @@ def extract_from_source(
             "path": path,
             "line": node.lineno,
             "params": params,
+            "guard": marker_guard(guards, enclosing_func),
         }
         scope = marker_scope(chain)
         if scope is None:
@@ -728,6 +894,8 @@ def _rule_message(
         return imported["message"]
     if matcher and matcher.get("in_class_base"):
         return _scoped_message(symbol, release, what)
+    if matcher and matcher["type"] in ("call_missing_arg_key", "call_missing_kwarg"):
+        return _missing_option_message(matcher, release, what)
     return what or _message_for(callee, symbol, release)
 
 
@@ -770,6 +938,7 @@ def build_rules(
                     record.get("scope"),
                     rejected,
                     record.get("params", ()),
+                    record.get("guard"),
                 )
                 if callee in API_DEPRECATION_CALLS
                 else None

--- a/tools/rules_engine.py
+++ b/tools/rules_engine.py
@@ -4,7 +4,7 @@ A *rule* says "this piece of Python stops working in Home Assistant release X".
 A *matcher* is the machine-checkable half of a rule.  :func:`match_source` runs
 every matcher over one parsed file and yields findings.
 
-Eleven matcher types cover every deprecation Breakage Radar currently ships:
+Twelve matcher types cover every deprecation Breakage Radar currently ships:
 
 ``moduledef``          a module-level ``def``/``async def`` with one of ``names``
 ``classbase``          a ``class`` whose base list mentions one of ``bases``
@@ -19,7 +19,14 @@ Eleven matcher types cover every deprecation Breakage Radar currently ships:
                        iterating the very same container is still supported
 ``call``               a call to one of ``names`` (bare or attribute access)
 ``call_kwarg``         a call to one of ``names`` passing any keyword in ``kwargs``
-``call_missing_kwarg`` a call to one of ``names`` *not* passing keyword ``kwarg``
+``call_missing_kwarg`` a call to one of ``names`` *not* passing keyword ``kwarg``,
+                       optionally only where every keyword in ``requires`` *is*
+                       passed -- core arms some of these checks conditionally
+``call_missing_arg_key``
+                       a call to one of ``names`` whose mapping argument (``arg``,
+                       ``arg_index``) provably does not set ``key``. For options
+                       core takes inside a ``TypedDict`` argument rather than as
+                       keywords, where a missing key is not visible on the call
 ``call_hass_argument`` a call to one of ``names`` that passes ``hass`` (first
                        positional or keyword) -- for ``@deprecated_hass_argument``,
                        where the *argument* is deprecated, not the function
@@ -65,6 +72,7 @@ MATCHER_TYPES = frozenset(
         "call",
         "call_kwarg",
         "call_missing_kwarg",
+        "call_missing_arg_key",
         "call_hass_argument",
         "import_from",
         "js",
@@ -74,7 +82,7 @@ MATCHER_TYPES = frozenset(
 #: Bumped whenever matching semantics change. It is folded into the crawl's
 #: rules hash, so an engine change forces a rescan instead of leaving stale
 #: findings that the current engine would no longer produce.
-ENGINE_VERSION = 9
+ENGINE_VERSION = 10
 
 VERSION_RE = re.compile(r"^\d{4}\.\d+(?:\.\d+)?$")
 
@@ -996,8 +1004,16 @@ def _match_call_kwarg(
 def _match_call_missing_kwarg(
     matcher: dict[str, Any], tree: ast.Module, imports: dict[str, str]
 ) -> Iterator[tuple[int, str]]:
+    """A call that omits a keyword core now requires.
+
+    ``requires`` is the rest of core's own guard.
+    ``async_update_statistics_metadata`` only warns about a missing
+    ``new_unit_class`` when ``new_unit_of_measurement`` is passed too, so a
+    call that passes neither is healthy and has to stay silent.
+    """
     names = set(matcher.get("names", ()))
     kwarg = matcher.get("kwarg")
+    requires = set(matcher.get("requires", ()))
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and _called_name(node) in names:
             if not _module_allowed(matcher, node, _called_name(node), imports):
@@ -1005,8 +1021,202 @@ def _match_call_missing_kwarg(
             # ``**kwargs`` (arg is None) could supply it -- do not guess.
             if any(keyword.arg is None for keyword in node.keywords):
                 continue
-            if not any(keyword.arg == kwarg for keyword in node.keywords):
+            passed = {keyword.arg for keyword in node.keywords}
+            if not requires <= passed:
+                continue
+            if kwarg not in passed:
                 yield node.lineno, f"{_called_name(node)}(no {kwarg})"
+
+
+#: Methods that add keys out of sight of the assignment that built the mapping.
+#: One of these on the name and the file can no longer say what it holds.
+MAPPING_MUTATORS = frozenset({"update", "setdefault", "pop", "popitem", "clear"})
+
+
+def _parents(tree: ast.Module) -> dict[ast.AST, ast.AST]:
+    return {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+
+
+def _enclosing_scope(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> ast.AST | None:
+    """The function or module whose body ``node`` sits in."""
+    current = parents.get(node)
+    while current is not None:
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module)):
+            return current
+        current = parents.get(current)
+    return None
+
+
+def _binds(target: ast.expr, name: str) -> bool:
+    return any(
+        isinstance(node, ast.Name) and node.id == name for node in ast.walk(target)
+    )
+
+
+def _mapping_keys(node: ast.expr, constructors: Collection[str]) -> set[str] | None:
+    """The keys a mapping expression sets, or ``None`` when it cannot be read.
+
+    A key counts as set wherever it is written, whatever the value: core tests
+    for the key itself, so ``{"unit_class": None}`` satisfies it.
+    """
+    if isinstance(node, ast.Dict):
+        keys = set()
+        for key in node.keys:
+            # ``{**base, "unit_class": x}``: ``base`` is not readable here.
+            if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
+                return None
+            keys.add(key.value)
+        return keys
+    if isinstance(node, ast.Call):
+        # The TypedDict's own constructor, ``StatisticMetaData(unit_class=...)``.
+        if _called_name(node) not in constructors or node.args:
+            return None
+        if any(keyword.arg is None for keyword in node.keywords):
+            return None
+        return {keyword.arg for keyword in node.keywords}
+    return None
+
+
+def _keys_bound_in(
+    name: str, scope: ast.AST, constructors: Collection[str]
+) -> tuple[bool, set[str] | None]:
+    """``(bound, keys)`` for ``name`` in ``scope``; ``keys`` is None if unreadable.
+
+    Deliberately flow-insensitive and inclusive: every assignment anywhere in
+    the scope counts, nested scopes included. Over-collecting keys only ever
+    silences a finding, which is the side to be wrong on here. Anything that
+    could set a key out of sight -- a computed subscript, unpacking, a mutator
+    method, the name being a parameter -- reads as unreadable rather than as
+    empty.
+    """
+    if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        arguments = scope.args
+        if name in {
+            arg.arg
+            for arg in (*_all_args(scope), arguments.vararg, arguments.kwarg)
+            if arg is not None
+        }:
+            return True, None
+
+    keys: set[str] = set()
+    bound = False
+    for node in ast.walk(scope):
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    if node.value is None:  # a bare ``x: SomeType`` annotation
+                        return True, None
+                    from_value = _mapping_keys(node.value, constructors)
+                    if from_value is None:
+                        return True, None
+                    keys |= from_value
+                    bound = True
+                elif (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == name
+                ):
+                    if not (
+                        isinstance(target.slice, ast.Constant)
+                        and isinstance(target.slice.value, str)
+                    ):
+                        return True, None
+                    keys.add(target.slice.value)
+                    bound = True
+                elif isinstance(target, (ast.Tuple, ast.List)) and _binds(target, name):
+                    return True, None
+        elif isinstance(node, ast.AugAssign) and _binds(node.target, name):
+            return True, None
+        elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)) and _binds(
+            node.target, name
+        ):
+            return True, None
+        elif isinstance(node, ast.withitem) and node.optional_vars is not None:
+            if _binds(node.optional_vars, name):
+                return True, None
+        elif isinstance(node, (ast.Global, ast.Nonlocal)) and name in node.names:
+            return True, None
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == name
+                and func.attr in MAPPING_MUTATORS
+            ):
+                return True, None
+    return bound, keys
+
+
+def _mapping_argument(node: ast.Call, matcher: dict[str, Any]) -> ast.expr | None:
+    """The mapping this call passes, positionally or by keyword."""
+    index = matcher.get("arg_index")
+    if index is not None and len(node.args) > index:
+        # A ``*args`` ahead of the slot moves whatever lands in it.
+        if any(isinstance(arg, ast.Starred) for arg in node.args[: index + 1]):
+            return None
+        return node.args[index]
+    return next(
+        (k.value for k in node.keywords if k.arg and k.arg == matcher.get("arg")),
+        None,
+    )
+
+
+def _resolve_mapping_name(
+    name: str,
+    node: ast.Call,
+    parents: dict[ast.AST, ast.AST],
+    constructors: Collection[str],
+) -> set[str] | None:
+    """Follow a name to the keys it holds, innermost scope outwards."""
+    scope = _enclosing_scope(node, parents)
+    while scope is not None:
+        bound, keys = _keys_bound_in(name, scope, constructors)
+        if bound:
+            return keys
+        scope = _enclosing_scope(scope, parents)
+    return None
+
+
+def _match_call_missing_arg_key(
+    matcher: dict[str, Any], tree: ast.Module, imports: dict[str, str]
+) -> Iterator[tuple[int, str]]:
+    """A call whose mapping argument provably does not set a required key.
+
+    Core's statistics helpers take their options inside ``metadata``, not as
+    keywords, so ``async_add_external_statistics(hass, metadata, stats)`` can
+    never pass ``unit_class=`` at all. Reading that guard as a keyword shipped
+    99 wrong findings over 96 integrations in 1.11.0 and was reported twice
+    (ReikanYsora/Helios-Forecast#38,
+    barisdemirdelen/homeassistant-greenchoice#66), both on code that sets the
+    key correctly. This one reads the mapping instead, and a mapping it cannot
+    read in full is never a finding.
+    """
+    names = set(matcher.get("names", ()))
+    key = matcher.get("key")
+    constructors = matcher.get("constructors", ())
+    parents: dict[ast.AST, ast.AST] | None = None
+
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and _called_name(node) in names):
+            continue
+        if not _module_allowed(matcher, node, _called_name(node), imports):
+            continue
+        argument = _mapping_argument(node, matcher)
+        if argument is None:
+            continue
+        keys = _mapping_keys(argument, constructors)
+        if keys is None and isinstance(argument, ast.Name):
+            if parents is None:
+                parents = _parents(tree)
+            keys = _resolve_mapping_name(argument.id, node, parents, constructors)
+        if keys is not None and key not in keys:
+            yield node.lineno, f"{_called_name(node)}(no {key})"
 
 
 def _looks_like_hass(node: ast.expr) -> bool:
@@ -1262,6 +1472,7 @@ _DISPATCH = {
     "call": _match_call,
     "call_kwarg": _match_call_kwarg,
     "call_missing_kwarg": _match_call_missing_kwarg,
+    "call_missing_arg_key": _match_call_missing_arg_key,
     "call_hass_argument": _match_call_hass_argument,
     "import_from": _match_import_from,
 }


### PR DESCRIPTION
`unit_class` and `mean_type` are keys of the `metadata` mapping that
`async_import_statistics` and `async_add_external_statistics` take as their
second argument. Neither function accepts a keyword by either name, so
`async_import_statistics(hass, metadata, stats, unit_class="energy")` is not
code anybody can write. The extractor read core's sentence, "doesn't specify
unit_class when calling async_import_statistics", as a keyword name and built a
`call_missing_kwarg` matcher from it. A keyword that cannot be passed is a
keyword that is always missing, so the rule fired on every call site in the
catalogue, the ones that set both keys correctly included.

Two maintainers reported it: ReikanYsora/Helios-Forecast#38 on 12 August, and
barisdemirdelen/homeassistant-greenchoice#66 on 11 September with the code that
proves it. Helios-Forecast had already restructured its metadata so a static
scanner would see the keys, with a comment saying so, and the board flagged it
anyway. Both issues stay open until the reporters confirm.

## The fix is in the layer that guessed

The extractor no longer derives any of this from the prose. It reads the `if`
the marker sits under.

`if "unit_class" not in metadata` is a key of the argument annotated
`StatisticMetaData`, so it becomes a `call_missing_arg_key` matcher carrying
the key, the parameter name, its position and the TypedDict's constructor:

```json
{"type": "call_missing_arg_key", "names": ["async_import_statistics"],
 "modules": ["homeassistant.components.recorder.statistics"],
 "key": "unit_class", "arg": "metadata", "arg_index": 1,
 "constructors": ["StatisticMetaData"]}
```

`if new_unit_of_measurement is not UNDEFINED and new_unit_class is UNDEFINED`
is a real keyword whose check core only arms when a new unit comes with it. The
rest of that condition becomes `requires` on `call_missing_kwarg`, so renaming
a statistic with `async_update_statistics_metadata` and no new unit was never a
problem and is no longer reported. A guard that fits neither shape is published
as prose with no matcher and counted in `discarded_markers` as
`unreadable_guard`.

The new matcher reads the mapping rather than the call. A dict literal, a
`StatisticMetaData(...)` call, or a local or module-level name that resolves to
one of those is readable, and a key written anywhere in it counts as set,
whatever its value, because presence is what core tests for. A mapping spread
from `**`, returned by a helper, mutated through `update()` or `setdefault()`,
subscripted with a computed key, or handed in as a parameter is not readable,
and nothing unreadable is ever a finding.

## Measured against what shipped

The 206 findings 1.11.0 published over 96 integrations, re-judged call site by
call site:

| | |
| --- | --- |
| still a finding | 26 |
| key or keyword provably set | 103 |
| mapping the scanner cannot read in full | 74 |
| not judged here, needs core's Python 3.14 to parse | 3 |

Taking the target from the enclosing `def` rather than the sentence also
recovers a rule that was missing entirely. Core's `mean_type` marker inside
`async_add_external_statistics` says "when calling async_import_statistics",
its own copy-paste, so both markers folded into one rule and the external half
was invisible: 16 real findings in the same corpus that 1.11.0 never reported.
There are five statistics rules now where there were four, and their ids
changed with their meaning.

24 tests in `tests/test_missing_option.py`, built off the real core guards
pinned in the test file rather than off `data/rules.json`, plus a false
positive fixture tree of 14 functions covering every correct and unreadable
shape that must stay silent and a true positive tree of 4 genuine findings.
495 passed, 3 skipped on 3.12.

`ENGINE_VERSION` is 10, which queues every repository for a rescan.
`data/rules.json` is left alone on purpose: it is generated on Python 3.14 by
the crawl, the committed copy still loads under the new engine, so this is safe
to merge ahead of the regeneration. The board keeps the stale findings until
the next run.

## Where I stopped on shared mechanism

The new scope walk in the engine is separate from `_walk_typed_scopes`, which
resolves annotated receivers for the attr matchers. difflib puts every new
engine function at or under 34% of its nearest neighbour, the 34% being
`_match_call_missing_arg_key` against `_match_call_hass_argument` and almost
all of that the module and import preamble every call matcher in the file
shares. Folding the two walks together would mean threading
`_walk_typed_scopes`' receiver and entry state through a callback, which costs
more than the handful of lines it saves, so they stay apart. In the extractor
`marker_guard` is 8% similar to the `marker_scope` it sits beside, and the one
line the two message builders did share is extracted as `_logs_it_as`.

One thing for upstream, not in this PR: core's `mean_type` message inside
`async_add_external_statistics` names the wrong function, which is worth a
one-line PR to home-assistant/core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
